### PR TITLE
add use_auto_torrent_management for qb downloading

### DIFF
--- a/src/core/download_client.py
+++ b/src/core/download_client.py
@@ -109,7 +109,8 @@ class DownloadClient:
         self.client.torrents_add(
             urls=torrent["url"],
             save_path=torrent["save_path"],
-            category="Bangumi"
+            category="Bangumi",
+            use_auto_torrent_management=True
         )
 
     def move_torrent(self, hashes, location):

--- a/src/downloader/qb_downloader.py
+++ b/src/downloader/qb_downloader.py
@@ -48,6 +48,7 @@ class QbDownloader:
             urls=urls,
             save_path=save_path,
             category=category,
+            use_auto_torrent_management=True,
         )
 
     def torrents_delete(self, hash):


### PR DESCRIPTION
Pull request by: Alex Liu

## Description

Added use_auto_torrent_management=True to file [src/core/download_client.py] and [src/downloader/qb_downloader.py]. Previous setting all always save files to default download folder set by qb regardless ENV in AB docker settings. This PR allows files to be saved into folders based on category settings and new ENV settings.

## Related Issues：
NA
