### PR TITLE
Add Bark Notification

### DIFF
--- a/src/module/manager/repath.py
+++ b/src/module/manager/repath.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from typing import List
 from dataclasses import dataclass
 from pathlib import PurePath, PureWindowsPath
 
@@ -38,7 +39,7 @@ class RepathTorrents:
         season = int(re.search(r"\d{1,2}", season_folder).group())
         return season, folder_name
 
-    def get_rule(self) -> [RuleInfo]:
+    def get_rule(self) -> List[RuleInfo]:
         rules = self._client.get_download_rules()
         all_rule = []
         for rule in rules:
@@ -50,7 +51,7 @@ class RepathTorrents:
         return all_rule
 
     @staticmethod
-    def get_difference(bangumi_data: list, rules: [RuleInfo]) -> [RuleInfo]:
+    def get_difference(bangumi_data: list, rules: List[RuleInfo]) -> List[RuleInfo]:
         different_data = []
         for data in bangumi_data:
             for rule in rules:
@@ -62,7 +63,7 @@ class RepathTorrents:
                         break
         return different_data
 
-    def get_matched_torrents_list(self, repath_rules: [RuleInfo]) -> [RePathInfo]:
+    def get_matched_torrents_list(self, repath_rules: List[RuleInfo]) -> List[RepathInfo]:
         infos = self._client.get_torrent_info()
         repath_list = []
         for rule in repath_rules:

--- a/src/module/network/notification.py
+++ b/src/module/network/notification.py
@@ -17,6 +17,8 @@ class PostNotification:
             return TelegramNotification()
         elif settings.notification.type.lower() == "server-chan":
             return ServerChanNotification()
+        elif settings.notification.type.lower() == "bark":
+            return BarkNotification()
         else:
             return None
 
@@ -60,4 +62,21 @@ class ServerChanNotification:
         with RequestContent() as req:
             resp = req.post_data(self.notification_url, data)
             logger.debug(f"ServerChan notification: {resp.status_code}")
+        return resp.status_code == 200
+
+
+class BarkNotification:
+    def __init__(self):
+        self.token = settings.notification.token
+        self.notification_url = "https://api.day.app/push"
+
+    def send_msg(self, title: str, desp: str):
+        data = {
+            "title": title,
+            "body": desp,
+            "device_key": self.token
+        }
+        with RequestContent() as req:
+            resp = req.post_data(self.notification_url, data)
+            logger.debug(f"Bark notification: {resp.status_code}")
         return resp.status_code == 200


### PR DESCRIPTION
 Similar to the [BangumiBot](https://github.com/RanKKI/BangumiBot#notification), we can use [Bark](https://bark.day.app/#/en-us/) for notification that is not limited to any specific application, but is based on Apple APNs.
 
 If this PR is merged, I will create a PR to add the notification type of Bark to [WebUI](https://github.com/Rewrite0/Auto_Bangumi_WebUI/blob/4552f097b5d2ee60318673786a0f0e6311f5b95d/src/pages/config/form-data.ts#L66).