### PR TITLE
fix: fix the Notification Type is not applied after changing it from WebUI

### DIFF
--- a/src/module/manager/renamer.py
+++ b/src/module/manager/renamer.py
@@ -139,12 +139,12 @@ class Renamer(DownloadClient):
                     if not renamed:
                         logger.warning(f"[Renamer] {subtitle_path} rename failed")
 
-    def rename(self):
+    def rename(self) -> list[Notification]:
         # Get torrent info
         logger.debug("[Renamer] Start rename process.")
         rename_method = settings.bangumi_manage.rename_method
         torrents_info = self.get_torrent_info()
-        renamed_info = []
+        renamed_info: list[Notification] = []
         for info in torrents_info:
             media_list, subtitle_list = self.check_files(info)
             bangumi_name, season = self._path_to_bangumi(info.save_path)

--- a/src/module/network/request_contents.py
+++ b/src/module/network/request_contents.py
@@ -42,11 +42,11 @@ class RequestContent(RequestURL):
         _url: str,
         _filter: str = "|".join(settings.rss_parser.filter),
         retry: int = 3,
-    ) -> [TorrentInfo]:
+    ) -> list[TorrentInfo]:
         try:
             soup = self.get_xml(_url, retry)
             torrent_titles, torrent_urls, torrent_homepage = mikan_parser(soup)
-            torrents = []
+            torrents: list[TorrentInfo] = []
             for _title, torrent_url, homepage in zip(
                 torrent_titles, torrent_urls, torrent_homepage
             ):

--- a/src/module/notification/notification.py
+++ b/src/module/notification/notification.py
@@ -10,7 +10,7 @@ from module.database import BangumiDatabase
 logger = logging.getLogger(__name__)
 
 
-def getClient(type=settings.notification.type):
+def getClient(type: str):
     if type.lower() == "telegram":
         return TelegramNotification
     elif type.lower() == "server-chan":
@@ -23,9 +23,10 @@ def getClient(type=settings.notification.type):
         return None
 
 
-class PostNotification(getClient()):
+class PostNotification:
     def __init__(self):
-        super().__init__(
+        Notifier = getClient(settings.notification.type)
+        self.notifier = Notifier(
             token=settings.notification.token,
             chat_id=settings.notification.chat_id
         )
@@ -48,12 +49,18 @@ class PostNotification(getClient()):
     def send_msg(self, notify: Notification) -> bool:
         text = self._gen_message(notify)
         try:
-            self.post_msg(text)
+            self.notifier.post_msg(text)
             logger.debug(f"Send notification: {notify.official_title}")
         except Exception as e:
             logger.warning(f"Failed to send notification: {e}")
             return False
 
+    def __enter__(self):
+        self.notifier.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.notifier.__exit__(exc_type, exc_val, exc_tb)
 
 if __name__ == "__main__":
     info = Notification(


### PR DESCRIPTION
**问题现象：**
- 在 WebUI 上修改 Notification Token，并同时修改 Notification Type 从 `telegram` 到 `brak` 并 Apply 后，
- 配置文件确实看到改了，但后台发送到请求还是走到 telegram，并且使用的新改的 Token
- 也就是只有 Notification Type 修改没生效

**问题来源：** tg 群内 @ZIZNAH, Close #288

**原因与修复：**
- 通知方式实际被 `PostNotification` 获取 client 类型的函数 `getClient` 的默认参数闭包固定住了
- 于是 `settings.notification.type` 的更新值并不会对 `getClient` 函数生效
- 修改为每次在 `PostNotification` 内初始化时显示传递 `settings.notification.type` 来示实例化一个通知客户端
 