### PR TITLE
feat: support parse config file with Variable Expansion for some secret keys

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Don't allow people to merge changes to these generated files, because the result
+# may be invalid.  You need to run "rush update" again.
+pnpm-lock.yaml               merge=binary
+shrinkwrap.yaml              merge=binary
+npm-shrinkwrap.json          merge=binary
+yarn.lock                    merge=binary
+
+# Rush's JSON config files use JavaScript-style code comments.  The rule below prevents pedantic
+# syntax highlighters such as GitHub's from highlighting these comments as errors.  Your text editor
+# may also require a special configuration to allow comments in JSON.
+#
+# For more information, see this issue: https://github.com/microsoft/rushstack/issues/1088
+#
+*.json                       linguist-language=JSON-with-Comments

--- a/.gitignore
+++ b/.gitignore
@@ -196,8 +196,11 @@ dist-ssr
 
 # Editor directories and files
 .vscode/*
-!.vscode/extensions.json
 !.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
 .idea
 .DS_Store
 *.suo

--- a/backend/dev.sh
+++ b/backend/dev.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is used to run the development environment.
 
 python3 -m venv venv
 
-./venv/bin/python3 -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple install -r requirements-dev.txt
+./venv/bin/python3 -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements-dev.txt
 
 # install git-hooks for pre-commit before committing.
 ./venv/bin/pre-commit install

--- a/backend/src/module/api/config.py
+++ b/backend/src/module/api/config.py
@@ -16,7 +16,7 @@ async def get_config(current_user=Depends(get_current_user)):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token"
         )
-    return settings
+    return settings.dict()
 
 
 @router.post("/updateConfig")

--- a/backend/src/module/database/orm/connector.py
+++ b/backend/src/module/database/orm/connector.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 
 from .delete import Delete
@@ -10,6 +11,10 @@ from module.conf import DATA_PATH
 
 class Connector:
     def __init__(self, table_name: str, data: dict, database: str = DATA_PATH):
+        # Create folder if not exists
+        if not os.path.exists(os.path.dirname(DATA_PATH)):
+            os.makedirs(os.path.dirname(DATA_PATH))
+
         self._conn = sqlite3.connect(database)
         self._cursor = self._conn.cursor()
         self.update = Update(self, table_name, data)

--- a/backend/src/module/models/config.py
+++ b/backend/src/module/models/config.py
@@ -1,3 +1,4 @@
+from os.path import expandvars
 from pydantic import BaseModel, Field
 
 # Sub config
@@ -12,21 +13,31 @@ class Program(BaseModel):
 class Downloader(BaseModel):
     type: str = Field("qbittorrent", description="Downloader type")
     host: str = Field("172.17.0.1:8080", description="Downloader host")
-    username: str = Field("admin", description="Downloader username")
-    password: str = Field("adminadmin", description="Downloader password")
+    username_: str = Field("admin", alias="username", description="Downloader username")
+    password_: str = Field("adminadmin", alias="password", description="Downloader password")
     path: str = Field("/downloads/Bangumi", description="Downloader path")
     ssl: bool = Field(False, description="Downloader ssl")
 
+    @property
+    def username(self):
+        return expandvars(self.username_)
+
+    @property
+    def password(self):
+        return expandvars(self.password_)
 
 class RSSParser(BaseModel):
     enable: bool = Field(True, description="Enable RSS parser")
     type: str = Field("mikan", description="RSS parser type")
-    token: str = Field("token", description="RSS parser token")
+    token_: str = Field("token", alias="token", description="RSS parser token")
     custom_url: str = Field("mikanani.me", description="Custom RSS host url")
     parser_type: str = Field("parser", description="Parser type")
     filter: list[str] = Field(["720", r"\d+-\d"], description="Filter")
     language: str = "zh"
 
+    @property
+    def token(self):
+        return expandvars(self.token_)
 
 class BangumiManage(BaseModel):
     enable: bool = Field(True, description="Enable bangumi manage")
@@ -45,16 +56,31 @@ class Proxy(BaseModel):
     type: str = Field("http", description="Proxy type")
     host: str = Field("", description="Proxy host")
     port: int = Field(0, description="Proxy port")
-    username: str = Field("", description="Proxy username")
-    password: str = Field("", description="Proxy password")
+    username_: str = Field("", alias="username", description="Proxy username")
+    password_: str = Field("", alias="password", description="Proxy password")
+
+    @property
+    def username(self):
+        return expandvars(self.username_)
+
+    @property
+    def password(self):
+        return expandvars(self.password_)
 
 
 class Notification(BaseModel):
     enable: bool = Field(False, description="Enable notification")
     type: str = Field("telegram", description="Notification type")
-    token: str = Field("", description="Notification token")
-    chat_id: str = Field("", description="Notification chat id")
+    token_: str = Field("", alias="token", description="Notification token")
+    chat_id_: str = Field("", alias="chat_id", description="Notification chat id")
 
+    @property
+    def token(self):
+        return expandvars(self.token_)
+
+    @property
+    def chat_id(self):
+        return expandvars(self.chat_id_)
 
 class Config(BaseModel):
     program: Program = Program()
@@ -64,3 +90,6 @@ class Config(BaseModel):
     log: Log = Log()
     proxy: Proxy = Proxy()
     notification: Notification = Notification()
+
+    def dict(self, *args, by_alias=True, **kwargs):
+        return super().dict(*args, by_alias=by_alias, **kwargs)


### PR DESCRIPTION
根据早期讨论的提案，在配置文件中对敏感 token 支持环境变量语法声明。

### 原始提案

一些用户会把把配置文件也用 git 管理，这样就算迁移和初始化都能直接应用配置生效，

但配置文件会遇到一些问题，目前 `config.json` 内有些 **secret keys** 和 common settings 同时在一个文件里，
这些 common settings 应该纳入版本控制，但 **secret keys** 不应该。

对于这种场景，本提案提出在 `config.json` 的特定 token 配置处，除了支持直接写 token/password 明文，还支持使用环境变量引用写法，例如

```json
   "token": "${MIKAN_TOKEN}",
   "password": "${THE_ADMIN_PASSWD}",
```

这项支持将保持最大的兼容性，仅新增解析功能，即使是对于 WebUI 的**更新/保存**也不会破坏配置安全性，即 WebUI 上也显示 token 为 `${MIKAN_TOKEN}` 这么一个原始字符串，保存时也是这么一个原始字符串。

--- 

### 实现与改动

本 PR 增加支持的配置项包括：

- `downloader.username`
- `downloader.password` 
- `rss_parser.token`
- `notification.token`
- `notification.chat_id`
- `proxy.username`
- `proxy.password`


**本次实现对代码中所有使用处无感无改动，实现原理：**

- 在 `pydantic` Model 上使用 `@property` getter 字段，通过原生 [`expandvars`](https://docs.python.org/3/library/os.path.html#os.path.expandvars) 方法做 shell 变量扩展([Variable expansion](https://unix.stackexchange.com/questions/403867/what-is-parameter-expansion-a-k-a-variable-expansion-in-shell-scripting-in))，
  
  用于支持原本形如 `settings.rss_parser.token` 直接访问的用法
- 对于 `pydantic` Field 字段添加 `alias` 字段支持，并对 `dict()` 方法添加默认 `by_alias` 参数，
  
  用于 Model 的序列化和反序列化过程中字段名称正确，以支持如下几种使用方式：
  - `settings.dict()`
  - `Config.parse_obj()`
  - `settings.__dict__.update()`

这总体使得所有访问值的地方(形如 `settings.rss_parser.token` ) 都能获取到展开后具体环境变量的值，

而通过 `settings.dict()` 给到 WebUI 和保存配置的是原始字符串 `${XXXX_VAR}`


