### PR TITLE
fix: 修复搜索番剧输入框报错后中断、不能再输入查询的问题

### DIFF
--- a/webui/src/components/basic/ab-search.vue
+++ b/webui/src/components/basic/ab-search.vue
@@ -3,7 +3,6 @@ import {Down, Search} from '@icon-park/vue-next';
 
 const {
   onSelect,
-  onInput,
   onSearch,
   inputValue,
   selectingProvider,
@@ -43,12 +42,11 @@ onMounted(() => {
     />
 
     <input
+        v-model="inputValue"
         type="text"
         :placeholder="$t('topbar.search.placeholder')"
         input-reset
-        :value="inputValue"
         @keyup.enter="onSearch"
-        @input="onInput"
     />
     <div
         h-full


### PR DESCRIPTION
- 报错信息改为 console 中展示，不打断 observer
- input 输入框改为 v-model 绑定，解决 IME 输入法输入时打断问题

待优化：
- 后端解析时报错信息应该和重新约定接口格式，将解析数据或报错信息都能返回到前端解析和提示
- 搜索项数据没限制，条数太多等时间太长没有意义
- 列表项的 UI 待优化，比如展示样式和点击添加/关闭啥的


---

列表项效果：

<img width="340" alt="image" src="https://github.com/EstrellaXD/Auto_Bangumi/assets/15135943/f358777c-b514-440e-969c-8de8903ae525">


报错提示 be like:

<img width="522" alt="image" src="https://github.com/EstrellaXD/Auto_Bangumi/assets/15135943/080e6977-f6fc-4674-9a75-b21ff34d731f">
