### PR TITLE
feat: remove `openai-python` dependency and replace it with pure `httpx` library

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,4 +26,4 @@ python-multipart==0.0.6
 sqlmodel==0.0.8
 sse-starlette==1.6.5
 semver==3.0.1
-openai==0.28.1
+httpx==0.25.0

--- a/backend/src/module/parser/analyser/openai.py
+++ b/backend/src/module/parser/analyser/openai.py
@@ -48,7 +48,7 @@ class OpenAIParser:
     def __init__(
         self,
         api_key: str,
-        api_base: str = "https://api.openai.com/v1",
+        api_base: str = "https://api.openai.com/",
         model: str = "gpt-3.5-turbo",
         **kwargs,
     ) -> None:
@@ -58,7 +58,7 @@ class OpenAIParser:
             api_key (str): the OpenAI api key
             api_base (str):
                 the OpenAI api base url, you can use custom url here. \
-                Defaults to "https://api.openai.com/v1".
+                Defaults to "https://api.openai.com/".
             model (str):
                 the ChatGPT model parameter, you can get more details from \
                 https://platform.openai.com/docs/api-reference/chat/create. \
@@ -74,8 +74,7 @@ class OpenAIParser:
             raise ValueError("API key is required.")
 
         self._api_key = api_key
-        # remove trailing slash
-        self.api_base = api_base.strip("/")
+        self.api_base = api_base
         self.model = model
         self.openai_kwargs = kwargs
 

--- a/backend/src/test/test_openai.py
+++ b/backend/src/test/test_openai.py
@@ -34,3 +34,24 @@ class TestOpenAIParser:
 
             result = self.parser.parse(text=text, asdict=False)
             assert json.loads(result) == expected
+
+    def test_parse_asdict(self):
+        text = "[梦蓝字幕组]New Doraemon 哆啦A梦新番[747][2023.02.25][AVC][1080P][GB_JP][MP4]"
+        expected = {
+            "group": "梦蓝字幕组",
+            "title_en": "New Doraemon",
+            "resolution": "1080P",
+            "episode": 747,
+            "season": 1,
+            "title_zh": "哆啦A梦新番",
+            "sub": "GB_JP",
+            "title_jp": "",
+            "season_raw": "2023.02.25",
+            "source": "AVC",
+        }
+
+        with mock.patch("module.parser.analyser.OpenAIParser.parse") as mocker:
+            mocker.return_value = expected
+
+            result = self.parser.parse(text=text)
+            assert result == expected


### PR DESCRIPTION
## New

## Change

## Fix

fix the gcc issue in docker ci. Becase `openai-python` library uses `aiohttp` for async requests, which needs gcc to compile. So just using `httpx`, a pure python implementation library, as an alternative. #507
