### PR TITLE
fix: :bug: 通知的内容包含无意义的前导和尾随空格

### DIFF
--- a/backend/src/module/notification/plugin/bark.py
+++ b/backend/src/module/notification/plugin/bark.py
@@ -17,7 +17,7 @@ class BarkNotification(RequestContent):
         text = f"""
         番剧名称：{notify.official_title}\n季度： 第{notify.season}季\n更新集数： 第{notify.episode}集\n{notify.poster_path}\n
         """
-        return text
+        return text.strip()
 
     def post_msg(self, notify: Notification) -> bool:
         text = self.gen_message(notify)

--- a/backend/src/module/notification/plugin/server_chan.py
+++ b/backend/src/module/notification/plugin/server_chan.py
@@ -18,7 +18,7 @@ class ServerChanNotification(RequestContent):
         text = f"""
         番剧名称：{notify.official_title}\n季度： 第{notify.season}季\n更新集数： 第{notify.episode}集\n{notify.poster_path}\n
         """
-        return text
+        return text.strip()
 
     def post_msg(self, notify: Notification) -> bool:
         text = self.gen_message(notify)

--- a/backend/src/module/notification/plugin/slack.py
+++ b/backend/src/module/notification/plugin/slack.py
@@ -17,7 +17,7 @@ class SlackNotification(RequestContent):
         text = f"""
         番剧名称：{notify.official_title}\n季度： 第{notify.season}季\n更新集数： 第{notify.episode}集\n{notify.poster_path}\n
         """
-        return text
+        return text.strip()
 
     def post_msg(self, notify: Notification) -> bool:
         text = self.gen_message(notify)

--- a/backend/src/module/notification/plugin/telegram.py
+++ b/backend/src/module/notification/plugin/telegram.py
@@ -18,7 +18,7 @@ class TelegramNotification(RequestContent):
         text = f"""
         番剧名称：{notify.official_title}\n季度： 第{notify.season}季\n更新集数： 第{notify.episode}集
         """
-        return text
+        return text.strip()
 
     def post_msg(self, notify: Notification) -> bool:
         text = self.gen_message(notify)

--- a/backend/src/module/notification/plugin/wecom.py
+++ b/backend/src/module/notification/plugin/wecom.py
@@ -20,7 +20,7 @@ class WecomNotification(RequestContent):
         text = f"""
         番剧名称：{notify.official_title}\n季度： 第{notify.season}季\n更新集数： 第{notify.episode}集\n{notify.poster_path}\n
         """
-        return text
+        return text.strip()
 
     def post_msg(self, notify: Notification) -> bool:
         ##Change message format to match Wecom push better


### PR DESCRIPTION
# 问题
通知的内容包含无意义的前导和尾随空格

现在通知信息内容生成的实现为
https://github.com/EstrellaXD/Auto_Bangumi/blob/0ef37f609b2b241f711efce16c89889b2e0fc771/backend/src/module/notification/plugin/bark.py#L16-L20

此实现会导致实际的推送信息为
`"\n\s\s\s\s\s\s\s\s番剧名称：{notify.official_title}\n季度： 第{notify.season}季\n更新集数： 第{notify.episode}集\n{notify.poster_path}\n\n\s\s\s\s\s\s\s\s"`

<img src="https://github.com/EstrellaXD/Auto_Bangumi/assets/83396062/25cb81e7-d087-4c1c-947d-28b5e8d4a48d" width="400">

整个通知模块正在被重构(#513), 重构后可能就不会有这个问题, 但是作为临时的解决方案我提交了这个pr


# 测试
- 仅测试了bark
- 把整个项目在本地跑起来太麻烦了使用以下代码进行的测试

```python
import requests
import time

poster_path = "https://test.poster_path.com/1.jpg"


class Notify:
    def __init__(self, official_title, season, episode, poster_path):
        self.official_title = official_title
        self.season = season
        self.episode = episode
        self.poster_path = poster_path


def notify(notify: Notify):
    token = "*******************"
    notification_url = "https://api.day.app/push"

    text = f"""
    番剧名称：{notify.official_title}\n季度： 第{notify.season}季\n更新集数： 第{notify.episode}集\n{notify.poster_path}\n
    """
    data1 = {"title": notify.official_title, "body": text, "device_key": token}
    data2 = {"title": notify.official_title, "body": text.strip(), "device_key": token}

    res = requests.post(notification_url, data1)
    print(
        f"已发送第一条通知, staute_code: {res.status_code}, text: {res.text}, reason: {res.reason}"
    )
    time.sleep(5)
    res = requests.post(notification_url, data2)
    print(
        f"已发送第二条通知, staute_code: {res.status_code}, text: {res.text}, reason: {res.reason}"
    )


notify_instance = Notify("Test_初音ミクの消失", 39, 39, poster_path)
notify(notify_instance)
```

## 测试结果
<img src="https://github.com/EstrellaXD/Auto_Bangumi/assets/83396062/adafebd4-f97f-4e49-aeca-57d8bdd78f1d" width="400">

