### PR TITLE
fix: 使用反代时 RSS 图标路径错误

### DIFF
--- a/webui/src/components/layout/ab-sidebar.vue
+++ b/webui/src/components/layout/ab-sidebar.vue
@@ -30,7 +30,7 @@ const { logout } = useAuth();
 const RSS = h(
   'span',
   { class: ['rel', 'left-2px'] },
-  h(InlineSvg, { src: '/images/RSS.svg' })
+  h(InlineSvg, { src: './images/RSS.svg' })
 );
 
 const items = [


### PR DESCRIPTION
使用反代时某图标路径错误：
<img width="1648" alt="iShot_2023-10-05_10 27 57" src="https://github.com/EstrellaXD/Auto_Bangumi/assets/8370450/35cdd435-998e-43cb-b659-63c829ef42f7">

<img width="1611" alt="iShot_2023-10-05_10 32 45" src="https://github.com/EstrellaXD/Auto_Bangumi/assets/8370450/97f75c0b-8419-4c0f-969c-8b4106b3d193">

