### PR TITLE
3.1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,7 +172,7 @@ cython_debug/
 
 /src/module/conf/config_dev.ini
 
-test.*
+
 .run
 /backend/src/templates/
 /backend/src/config/
@@ -190,6 +190,7 @@ lerna-debug.log*
 
 node_modules
 dist
+webui/.vite/deps/*
 dist.zip
 dist-ssr
 *.local

--- a/backend/src/module/conf/__init__.py
+++ b/backend/src/module/conf/__init__.py
@@ -8,5 +8,6 @@ TMDB_API = "32b19d6a05b512190a056fa4e747cbbc"
 DATA_PATH = "sqlite:///data/data.db"
 LEGACY_DATA_PATH = Path("data/data.json")
 VERSION_PATH = Path("config/version.info")
+POSTERS_PATH = Path("data/posters")
 
 PLATFORM = "Windows" if "\\" in settings.downloader.path else "Unix"

--- a/backend/src/module/core/program.py
+++ b/backend/src/module/core/program.py
@@ -36,6 +36,9 @@ class Program(RenameThread, RSSThread):
         if not self.database:
             first_run()
             logger.info("[Core] No db file exists, create database file.")
+            if not self.img_cache:
+                logger.info("[Core] No image cache exists, create image cache.")
+                cache_image()
             return {"status": "First run detected."}
         if self.legacy_data:
             logger.info(

--- a/backend/src/module/core/program.py
+++ b/backend/src/module/core/program.py
@@ -36,9 +36,6 @@ class Program(RenameThread, RSSThread):
         if not self.database:
             first_run()
             logger.info("[Core] No db file exists, create database file.")
-            if not self.img_cache:
-                logger.info("[Core] No image cache exists, create image cache.")
-                cache_image()
             return {"status": "First run detected."}
         if self.legacy_data:
             logger.info(

--- a/backend/src/module/manager/collector.py
+++ b/backend/src/module/manager/collector.py
@@ -53,8 +53,9 @@ class SeasonCollector(DownloadClient):
             engine.add_rss(
                 rss_link=data.rss_link, name=data.official_title, aggregate=False
             )
+            result = engine.download_bangumi(data)
             engine.bangumi.add(data)
-            return engine.download_bangumi(data)
+            return result
 
 
 def eps_complete():

--- a/backend/src/module/manager/torrent.py
+++ b/backend/src/module/manager/torrent.py
@@ -40,19 +40,16 @@ class TorrentManager(Database):
         data = self.bangumi.search_id(int(_id))
         if isinstance(data, Bangumi):
             with DownloadClient() as client:
-                # client.remove_rule(data.rule_name)
-                # client.remove_rss_feed(data.official_title)
                 self.rss.delete(data.official_title)
                 self.bangumi.delete_one(int(_id))
                 if file:
                     torrent_message = self.delete_torrents(data, client)
-                    return torrent_message
                 logger.info(f"[Manager] Delete rule for {data.official_title}")
                 return ResponseModel(
                     status_code=200,
                     status=True,
-                    msg_en=f"Delete rule for {data.official_title}",
-                    msg_zh=f"删除 {data.official_title} 规则",
+                    msg_en=f"Delete rule for {data.official_title}. {torrent_message.msg_en if file else ''}",
+                    msg_zh=f"删除 {data.official_title} 规则。{torrent_message.msg_zh if file else ''}",
                 )
         else:
             return ResponseModel(

--- a/backend/src/module/parser/analyser/mikan_parser.py
+++ b/backend/src/module/parser/analyser/mikan_parser.py
@@ -1,3 +1,5 @@
+import re
+
 from bs4 import BeautifulSoup
 from urllib3.util import parse_url
 
@@ -14,6 +16,7 @@ def mikan_parser(homepage: str):
         official_title = soup.select_one(
             'p.bangumi-title a[href^="/Home/Bangumi/"]'
         ).text
+        official_title = re.sub(r"第.*季", "", official_title)
         if poster_div:
             poster_path = poster_div.split("url('")[1].split("')")[0]
             img = req.get_content(f"https://{root_path}{poster_path}")

--- a/backend/src/module/rss/analyser.py
+++ b/backend/src/module/rss/analyser.py
@@ -82,16 +82,14 @@ class RSSAnalyser(TitleParser):
 
     def link_to_data(self, rss: RSSItem) -> Bangumi | ResponseModel:
         torrents = self.get_rss_torrents(rss.url, False)
-        try:
-            for torrent in torrents:
-                data = self.torrent_to_data(torrent, rss)
-                if data:
-                    return data
-        except Exception as e:
-            logger.debug(e)
-            return ResponseModel(
-                status=False,
-                status_code=406,
-                msg_en="No new title has been found.",
-                msg_zh="没有找到新的番剧。",
-            )
+        for torrent in torrents:
+            data = self.torrent_to_data(torrent, rss)
+            if data:
+                return data
+            else:
+                return ResponseModel(
+                    status=False,
+                    status_code=406,
+                    msg_en="Cannot parse this link.",
+                    msg_zh="无法解析此链接。",
+                )

--- a/backend/src/module/update/startup.py
+++ b/backend/src/module/update/startup.py
@@ -1,6 +1,7 @@
 import logging
 
 from module.rss import RSSEngine
+from module.conf import POSTERS_PATH
 
 logger = logging.getLogger(__name__)
 
@@ -15,3 +16,4 @@ def first_run():
     with RSSEngine() as engine:
         engine.create_table()
         engine.user.add_default_user()
+    POSTERS_PATH.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Fix

- TG 通知无法发送的问题 #553 
- 初次启动无法创建`posters`文件夹的问题
- 通过解析订阅的新番可能缺少 `save_path` 的问题 #565
- 移除蜜柑官方解析名称中的 `第*季` #541 
- 删除番剧时找不到对应种子文件导致的错误。 #523 