### PR TITLE
Remove token from window.localStorage​ (fix XSS leak)

### DIFF
--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -11,8 +11,8 @@ const theme: GlobalThemeOverrides = {
   },
 };
 
-const { refresh, isLogin } = useAuth();
-if (isLogin.value) {
+const { refresh, isLoggedin } = useAuth();
+if (isLoggedin.value === true) {
   refresh();
 }
 </script>

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -13,7 +13,9 @@ const theme: GlobalThemeOverrides = {
 
 const { refresh, isLoggedin } = useAuth();
 
-refresh();
+if(isLoggedin.value){
+  refresh();
+}
 
 </script>
 

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -12,9 +12,9 @@ const theme: GlobalThemeOverrides = {
 };
 
 const { refresh, isLoggedin } = useAuth();
-if (isLoggedin.value === true) {
-  refresh();
-}
+
+refresh();
+
 </script>
 
 <template>

--- a/webui/src/hooks/useAppInfo.ts
+++ b/webui/src/hooks/useAppInfo.ts
@@ -11,7 +11,9 @@ export const useAppInfo = createSharedComposable(() => {
       version.value = res.version;
     });
 
-    execute();
+    if (isLoggedin.value) {
+      execute();
+    }
   }
 
   const { pause: offUpdate, resume: onUpdate } = useIntervalFn(

--- a/webui/src/hooks/useAppInfo.ts
+++ b/webui/src/hooks/useAppInfo.ts
@@ -1,5 +1,5 @@
 export const useAppInfo = createSharedComposable(() => {
-  const { auth } = useAuth();
+  const { isLoggedin } = useAuth();
   const running = ref<boolean>(false);
   const version = ref<string>('');
 
@@ -11,7 +11,7 @@ export const useAppInfo = createSharedComposable(() => {
       version.value = res.version;
     });
 
-    if (auth.value !== '') {
+    if (isLoggedin.value !== false) {
       execute();
     }
   }

--- a/webui/src/hooks/useAppInfo.ts
+++ b/webui/src/hooks/useAppInfo.ts
@@ -11,9 +11,7 @@ export const useAppInfo = createSharedComposable(() => {
       version.value = res.version;
     });
 
-    if (isLoggedin.value !== false) {
-      execute();
-    }
+    execute();
   }
 
   const { pause: offUpdate, resume: onUpdate } = useIntervalFn(

--- a/webui/src/hooks/useAuth.ts
+++ b/webui/src/hooks/useAuth.ts
@@ -2,7 +2,7 @@ import type { User } from '#/auth';
 import type { ApiError } from '#/api';
 
 export const useAuth = createSharedComposable(() => {
-  const auth = useLocalStorage('auth', '');
+  const isLoggedin = useLocalStorage('isLoggedin', false);
   const message = useMessage();
 
   const user = reactive<User>({
@@ -10,7 +10,6 @@ export const useAuth = createSharedComposable(() => {
     password: '',
   });
 
-  const isLogin = computed(() => auth.value === '1');
 
   function clearUser() {
     user.username = '';
@@ -39,7 +38,7 @@ export const useAuth = createSharedComposable(() => {
     });
 
     onResult((res) => {
-      auth.value = `1`;
+      isLoggedin.value = true;
       clearUser();
     });
 
@@ -68,7 +67,7 @@ export const useAuth = createSharedComposable(() => {
 
   onLogoutResult(() => {
     clearUser();
-    auth.value = '';
+    isLoggedin.value = false;
   });
 
   const { execute: refresh, onResult: onRefreshResult } = useApi(
@@ -76,7 +75,7 @@ export const useAuth = createSharedComposable(() => {
   );
 
   onRefreshResult((res) => {
-    auth.value = `1`;
+    isLoggedin.value = true;
   });
 
   function update() {
@@ -90,7 +89,7 @@ export const useAuth = createSharedComposable(() => {
 
     onResult((res) => {
       if (res.message === 'update success') {
-        auth.value = ``;
+        isLoggedin.value = false;
         clearUser();
       } else {
         user.password = '';
@@ -107,9 +106,8 @@ export const useAuth = createSharedComposable(() => {
   }
 
   return {
-    auth,
+    isLoggedin,
     user,
-    isLogin,
 
     login,
     logout,

--- a/webui/src/hooks/useAuth.ts
+++ b/webui/src/hooks/useAuth.ts
@@ -10,7 +10,7 @@ export const useAuth = createSharedComposable(() => {
     password: '',
   });
 
-  const isLogin = computed(() => auth.value !== '');
+  const isLogin = computed(() => auth.value === '1');
 
   function clearUser() {
     user.username = '';
@@ -39,7 +39,7 @@ export const useAuth = createSharedComposable(() => {
     });
 
     onResult((res) => {
-      auth.value = `${res.token_type} ${res.access_token}`;
+      auth.value = `1`;
       clearUser();
     });
 
@@ -76,7 +76,7 @@ export const useAuth = createSharedComposable(() => {
   );
 
   onRefreshResult((res) => {
-    auth.value = `${res.token_type} ${res.access_token}`;
+    auth.value = `1`;
   });
 
   function update() {
@@ -90,7 +90,7 @@ export const useAuth = createSharedComposable(() => {
 
     onResult((res) => {
       if (res.message === 'update success') {
-        auth.value = `${res.token_type} ${res.access_token}`;
+        auth.value = ``;
         clearUser();
       } else {
         user.password = '';

--- a/webui/src/hooks/useAuth.ts
+++ b/webui/src/hooks/useAuth.ts
@@ -89,7 +89,6 @@ export const useAuth = createSharedComposable(() => {
 
     onResult((res) => {
       if (res.message === 'update success') {
-        isLoggedin.value = false;
         clearUser();
       } else {
         user.password = '';

--- a/webui/src/router/index.ts
+++ b/webui/src/router/index.ts
@@ -5,14 +5,14 @@ const router = createRouter({
 });
 
 router.beforeEach((to) => {
-  const { isLogin } = useAuth();
+  const { isLoggedin } = useAuth();
   const { type, url } = storeToRefs(usePlayerStore());
 
-  if (!isLogin.value && to.path !== '/login') {
+  if (!isLoggedin.value && to.path !== '/login') {
     return { name: 'Login' };
   }
 
-  if (isLogin.value && to.path === '/login') {
+  if (isLoggedin.value && to.path === '/login') {
     return { name: 'Index' };
   }
 
@@ -21,7 +21,7 @@ router.beforeEach((to) => {
     return false;
   }
 
-  watch(isLogin, (val) => {
+  watch(isLoggedin, (val) => {
     if (to.path === '/login' && val) {
       router.replace({ name: 'Index' });
     }

--- a/webui/src/store/log.ts
+++ b/webui/src/store/log.ts
@@ -10,9 +10,7 @@ export const useLogStore = defineStore('log', () => {
       log.value = value;
     });
 
-    if (isLoggedin.value !== false) {
-      execute();
-    }
+    execute();
   }
 
   const { execute: reset, onResult: onClearLogResult } = useApi(

--- a/webui/src/store/log.ts
+++ b/webui/src/store/log.ts
@@ -1,6 +1,6 @@
 export const useLogStore = defineStore('log', () => {
   const log = ref('');
-  const { auth } = useAuth();
+  const { isLoggedin } = useAuth();
   const message = useMessage();
 
   function get() {
@@ -10,7 +10,7 @@ export const useLogStore = defineStore('log', () => {
       log.value = value;
     });
 
-    if (auth.value !== '') {
+    if (isLoggedin.value !== false) {
       execute();
     }
   }

--- a/webui/src/store/log.ts
+++ b/webui/src/store/log.ts
@@ -10,7 +10,9 @@ export const useLogStore = defineStore('log', () => {
       log.value = value;
     });
 
-    execute();
+    if (isLoggedin.value) {
+      execute();
+    }
   }
 
   const { execute: reset, onResult: onClearLogResult } = useApi(

--- a/webui/src/utils/axios.ts
+++ b/webui/src/utils/axios.ts
@@ -35,8 +35,8 @@ axios.interceptors.response.use(
 
     /** token 过期 */
     if (error.status === 401) {
-      const { auth } = useAuth();
-      auth.value = '';
+      const { isLoggedin } = useAuth();
+      isLoggedin.value = false;
     }
 
     /** 执行失败 */


### PR DESCRIPTION
window.localStorage 很容易就能被浏览器的扩展程序读取，而JWT实现并不依赖于位于 localStorage 里的 auth 存储。Cookie 即可。

所以这么存 token 的方式属于严重白给。

在修改后的 auth 下只需要存登录态即可。