### PR TITLE
fix: subtitle file rename failure in collection

### DIFF
--- a/backend/src/module/parser/analyser/torrent_parser.py
+++ b/backend/src/module/parser/analyser/torrent_parser.py
@@ -69,36 +69,37 @@ def torrent_parser(
     file_type: str = "media",
 ) -> EpisodeFile | SubtitleFile:
     media_path = get_path_basename(torrent_path)
-    for rule in RULES:
-        if torrent_name:
-            match_obj = re.match(rule, torrent_name, re.I)
-        else:
-            match_obj = re.match(rule, media_path, re.I)
-        if match_obj:
-            group, title = get_group(match_obj.group(1))
-            if not season:
-                title, season = get_season_and_title(title)
-            else:
-                title, _ = get_season_and_title(title)
-            episode = int(match_obj.group(2))
-            suffix = Path(torrent_path).suffix
-            if file_type == "media":
-                return EpisodeFile(
-                    media_path=torrent_path,
-                    group=group,
-                    title=title,
-                    season=season,
-                    episode=episode,
-                    suffix=suffix,
-                )
-            elif file_type == "subtitle":
-                language = get_subtitle_lang(media_path)
-                return SubtitleFile(
-                    media_path=torrent_path,
-                    group=group,
-                    title=title,
-                    season=season,
-                    language=language,
-                    episode=episode,
-                    suffix=suffix,
-                )
+    match_names = [torrent_name, media_path]
+    if torrent_name is None:
+        match_names = match_names[1:]
+    for match_name in match_names:
+        for rule in RULES:
+            match_obj = re.match(rule, match_name, re.I)
+            if match_obj:
+                group, title = get_group(match_obj.group(1))
+                if not season:
+                    title, season = get_season_and_title(title)
+                else:
+                    title, _ = get_season_and_title(title)
+                episode = int(match_obj.group(2))
+                suffix = Path(torrent_path).suffix
+                if file_type == "media":
+                    return EpisodeFile(
+                        media_path=torrent_path,
+                        group=group,
+                        title=title,
+                        season=season,
+                        episode=episode,
+                        suffix=suffix,
+                    )
+                elif file_type == "subtitle":
+                    language = get_subtitle_lang(media_path)
+                    return SubtitleFile(
+                        media_path=torrent_path,
+                        group=group,
+                        title=title,
+                        season=season,
+                        language=language,
+                        episode=episode,
+                        suffix=suffix,
+                    )


### PR DESCRIPTION
# Fix

#391 

***

另外还有两个问题：

- 当字幕没有语种信息时（[SumiSora][Tanakeda][02][x265_aac](3E01D620).ass）会命名失败，是否可将SubtitleFile.language类型改为Optional[str]？

- 关于非zh-tw|zh语种，因为语种信息一般是倒数第二个后缀（中二病也要谈恋爱！ - S01E01 - 邂逅的…邪王真眼.jpn.ass），代码是否可以改为：

```python
from pathlib import Path

def get_subtitle_lang(subtitle_name: str) -> str:
    for key, value in SUBTITLE_LANG.items():
        for v in value:
            if v in subtitle_name.lower():
                return key
            
    suffixes = Path(subtitle_name).suffixes
    if len(suffixes) > 1:
        lang = suffixes[-2]
        return lang.lstrip(".")
```
