### PR TITLE
fix: Mikan some torrents are not a valid torrent file

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,3 +27,5 @@ sqlmodel==0.0.8
 sse-starlette==1.6.5
 semver==3.0.1
 openai==0.28.1
+torrentool==1.2.0
+lxml==5.2.2

--- a/backend/src/module/network/request_contents.py
+++ b/backend/src/module/network/request_contents.py
@@ -2,6 +2,8 @@ import logging
 import re
 import xml.etree.ElementTree
 
+from lxml import etree
+
 from module.conf import settings
 from module.models import Torrent
 
@@ -73,3 +75,9 @@ class RequestContent(RequestURL):
         soup = self.get_xml(_url)
         if soup:
             return soup.find("./channel/title").text
+
+    def get_magnet(self, _url) -> str | None:
+        html = etree.HTML(self.get_html(_url))
+        magnet = html.xpath('//a[starts-with(@href, "magnet")]/@href')
+        if magnet:
+            return magnet[0]

--- a/backend/src/module/utils/__init__.py
+++ b/backend/src/module/utils/__init__.py
@@ -1,1 +1,2 @@
 from .cache_image import save_image, load_image
+from .torrent import check_torrent

--- a/backend/src/module/utils/torrent.py
+++ b/backend/src/module/utils/torrent.py
@@ -1,0 +1,11 @@
+from torrentool.bencode import Bencode
+from torrentool.exceptions import BencodeDecodingError
+
+
+def check_torrent(content: bytes) -> bool:
+    try:
+        if Bencode.decode(content):
+            return True
+        return False
+    except BencodeDecodingError:
+        return False


### PR DESCRIPTION
# Fix

- Mikan有些torrent为空文件, 比如https://mikanani.me/Download/20240510/d6ab9c13dda6c7b8dbf972130c67a2c219aea844.torrent (【幻樱字幕组】【1月新番】【迷宫饭 Dungeon Meshi】【19】【GB_MP4】【1920X1080】)

- Close #774, #770