### PR TITLE
添加Bark消息推送更多参数设置

### DIFF
--- a/backend/src/module/notification/plugin/bark.py
+++ b/backend/src/module/notification/plugin/bark.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from module.models import Notification
 from module.network import RequestContent
@@ -7,9 +8,10 @@ logger = logging.getLogger(__name__)
 
 
 class BarkNotification(RequestContent):
-    def __init__(self, token, **kwargs):
+    def __init__(self, token: str, bark_params: Optional[dict], **kwargs) -> None:
         super().__init__()
         self.token = token
+        self.params = bark_params
         self.notification_url = "https://api.day.app/push"
 
     @staticmethod
@@ -21,7 +23,14 @@ class BarkNotification(RequestContent):
 
     def post_msg(self, notify: Notification) -> bool:
         text = self.gen_message(notify)
-        data = {"title": notify.official_title, "body": text, "icon": notify.poster_path, "device_key": self.token}
+        data = {
+            "title": notify.official_title,
+            "body": text,
+            "icon": notify.poster_path,
+            "device_key": self.token,
+        }
+        if isinstance(self.params, dict):
+            data.update(self.params)
         resp = self.post_data(self.notification_url, data)
         logger.debug(f"Bark notification: {resp.status_code}")
         return resp.status_code == 200

--- a/backend/src/module/notification/plugin/bark.py
+++ b/backend/src/module/notification/plugin/bark.py
@@ -8,11 +8,25 @@ logger = logging.getLogger(__name__)
 
 
 class BarkNotification(RequestContent):
-    def __init__(self, token: str, bark_params: Optional[dict], **kwargs) -> None:
+    def __init__(
+        self,
+        token: str,
+        bark_params: Optional[dict],
+        bark_server: Optional[str],
+        **kwargs,
+    ) -> None:
         super().__init__()
         self.token = token
         self.params = bark_params
-        self.notification_url = "https://api.day.app/push"
+        if bark_server is not None:
+            if not bark_server.startswith("http"):
+                bark_server = "https://" + bark_server
+            if not bark_server.endswith("push"):
+                bark_server = bark_server.rstrip("/") + "/push"
+
+            self.notification_url = bark_server
+        else:
+            self.notification_url = "https://api.day.app/push"
 
     @staticmethod
     def gen_message(notify: Notification) -> str:

--- a/webui/types/config.ts
+++ b/webui/types/config.ts
@@ -46,6 +46,7 @@ export interface Config {
     type: 'telegram' | 'server-chan' | 'bark' | 'wecom';
     token: string;
     chat_id: string;
+    bark_params: string;
   };
   experimental_openai: {
     enable: boolean;

--- a/webui/types/config.ts
+++ b/webui/types/config.ts
@@ -47,6 +47,7 @@ export interface Config {
     token: string;
     chat_id: string;
     bark_params: string;
+    bark_server: string;
   };
   experimental_openai: {
     enable: boolean;


### PR DESCRIPTION
#792 
除此之外还添加了自定义Bark服务器的支持：
- 检查url是否完整，若只添加`host:port`默认使用https协议
- 检查uri部分是否完整，若不完整自动添加`/push`
