### PR TITLE
feat: Add ntfy notification method

### DIFF
--- a/backend/src/module/notification/notification.py
+++ b/backend/src/module/notification/notification.py
@@ -9,6 +9,7 @@ from .plugin import (
     ServerChanNotification,
     TelegramNotification,
     WecomNotification,
+    NtfyNotification,
 )
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,8 @@ def getClient(type: str):
         return BarkNotification
     elif type.lower() == "wecom":
         return WecomNotification
+    elif type.lower() == 'ntfy':
+        return NtfyNotification
     else:
         return None
 

--- a/backend/src/module/notification/plugin/__init__.py
+++ b/backend/src/module/notification/plugin/__init__.py
@@ -2,3 +2,4 @@ from .bark import BarkNotification
 from .server_chan import ServerChanNotification
 from .telegram import TelegramNotification
 from .wecom import WecomNotification
+from .ntfy import NtfyNotification

--- a/backend/src/module/notification/plugin/ntfy.py
+++ b/backend/src/module/notification/plugin/ntfy.py
@@ -1,0 +1,31 @@
+import logging
+
+from module.models import Notification
+from module.network import RequestContent
+
+logger = logging.getLogger(__name__)
+
+
+class NtfyNotification(RequestContent):
+    def __init__(self, token, chat_id, **kwargs):
+        super().__init__()
+        
+        self.notification_url = f"{chat_id}"
+        self.token = token
+    
+    @staticmethod
+    def gen_message(notify: Notification) -> str:
+        text = f"""
+        番剧名称：{notify.official_title}\n季度： 第{notify.season}季\n更新集数： 第{notify.episode}集\n
+        """
+        return text.strip()
+    
+    def post_msg(self, notify: Notification) -> bool:
+        text = self.gen_message(notify)
+        self.header["Authorization"] = "Bearer " + self.token
+        self.header["Title"] = notify.official_title.encode('utf-8')
+        # self.header["Icon"] =  notify.poster_path
+        data = text.encode('utf-8')
+        resp = self.post_data(self.notification_url, data)
+        logger.debug(f"ServerChan notification: {resp.status_code}")
+        return resp.status_code == 200

--- a/webui/src/components/setting/config-notification.vue
+++ b/webui/src/components/setting/config-notification.vue
@@ -11,6 +11,7 @@ const notificationType: NotificationType = [
   'server-chan',
   'bark',
   'wecom',
+  'ntfy',
 ];
 
 const items: SettingItem<Notification>[] = [

--- a/webui/types/config.ts
+++ b/webui/types/config.ts
@@ -43,7 +43,7 @@ export interface Config {
   };
   notification: {
     enable: boolean;
-    type: 'telegram' | 'server-chan' | 'bark' | 'wecom';
+    type: 'telegram' | 'server-chan' | 'bark' | 'wecom' | 'ntfy';
     token: string;
     chat_id: string;
   };


### PR DESCRIPTION
仿照其他的通知方式，添加了 ntfy 的通知方式。
通知方式的选项里添加 ntfy 选项，chat id 填入要推送的 url， token 就填 ntfy 的账号的 token 即可。

由于中文 post 上去会失败，所以这里对可能包含中文的地方用 utf-8 编码了下。

这里的 data 直接用 str 的原因为不改动原来接口。要让 ntfy 识别为 data 为 json，推送的 url 里面不能包含 topic。当前设计是在 chatid 处填入包含 topic 的 url，自己手工分离 topic 出来过于麻烦，故直接传了 str 当 data。

自己测了下功能正常
![微信图片编辑_20240723225117](https://github.com/user-attachments/assets/2681465f-0dd2-4c17-a2de-0a1cffdbf24a)
![微信截图_20240723212852](https://github.com/user-attachments/assets/df473c97-cace-44a2-a547-7c964c6c6135)



