### PR TITLE
fix: 修复因 KeyError 导致解析错误

### DIFF
--- a/backend/src/module/parser/analyser/raw_parser.py
+++ b/backend/src/module/parser/analyser/raw_parser.py
@@ -75,8 +75,11 @@ def season_process(season_info: str):
             try:
                 season = int(season_pro)
             except ValueError:
-                season = CHINESE_NUMBER_MAP[season_pro]
-                break
+                if season_pro in CHINESE_NUMBER_MAP:
+                    season = CHINESE_NUMBER_MAP[season_pro]
+                    break
+    else:
+        return name_season, "", 1
     return name, season_raw, season
 
 


### PR DESCRIPTION
解决了在处理类似 `物语系列 第外季＆第怪季` 这样的字符串时出现的 `KeyError` 问题