### PR TITLE
fix: None official_title in bangumi stopping rss parsing

### DIFF
--- a/backend/src/module/rss/analyser.py
+++ b/backend/src/module/rss/analyser.py
@@ -31,7 +31,8 @@ class RSSAnalyser(TitleParser):
             bangumi.poster_link = poster_link
         else:
             pass
-        bangumi.official_title = re.sub(r"[/:.\\]", " ", bangumi.official_title)
+        if bangumi.official_title:
+            bangumi.official_title = re.sub(r"[/:.\\]", " ", bangumi.official_title)
 
     @staticmethod
     def get_rss_torrents(rss_link: str, full_parse: bool = True) -> list[Torrent]:


### PR DESCRIPTION
解析搜索结果时会发生`raw_parser`成功生成Bangumi但是此对象`title_raw`为`None`造成`official_title_parser`替换字符时报错，解析中断。
这个PR主要为了继续解析队列会对这个Bangumi“放行”。
其他`raw_parser`优化可能：
1. 优化解析不要造成false positive，不过我遇到的例子是rss link也是空的，不晓得会不会有rss link有但是title为空？
2. `official_title = title_raw` 这行改为 `official_title = title_raw or ""` （？

重现：
搜索“紫罗兰”会在rss item 
`[致命紫罗兰004/Ultraviolet Code 044][01][BDRIP][1920x1080][机翻中文字幕] `
出现以上情况。