### PR TITLE
fix: downloader check blocking issue while startup 修复下载器检查逻辑阻塞程序启动问题

### DIFF
--- a/backend/src/module/core/program.py
+++ b/backend/src/module/core/program.py
@@ -61,10 +61,8 @@ class Program(RenameThread, RSSThread):
     async def start(self):
         self.stop_event.clear()
         settings.load()
-        while not self.downloader_status:
-            logger.warning("Downloader is not running.")
-            logger.info("Waiting for downloader to start.")
-            await asyncio.sleep(30)
+        if not self.downloader_status:
+            logger.warning("Unable to connect to the downloader, some features may not be available until connected.")
         if self.enable_renamer:
             self.rename_start()
         if self.enable_rss:


### PR DESCRIPTION
Fixes #891.

这个 PR 尝试在 `start` 阶段只进行一次检查，如果下载器未就绪，则抛出一个警告，而非阻塞程序启动。

若下载功能调用 qb 失败，则异常会由那些下载逻辑来处理（也应当如此，因为初始检查是不可靠的，qb 作为外部服务随时可能在后续生命周期发生断连或不可用）。