### PR TITLE
[fix] better json parsing in openai.py to be compatible with more GPTs

### DIFF
--- a/backend/src/module/parser/analyser/openai.py
+++ b/backend/src/module/parser/analyser/openai.py
@@ -109,7 +109,7 @@ class OpenAIParser:
 
         if asdict:
             try:
-                result = json.loads(result)
+                result = json.loads(result[result.index("{"):result.rindex("}") + 1])    # find the first { and last } for better compatibility
             except json.JSONDecodeError:
                 logger.warning(f"Cannot parse result {result} as python dict.")
 


### PR DESCRIPTION
Try the best to get an json object from GPT responses, since other gpt apis (here as moonshot) may not support json mode.
```log
AutoBangumi     | [2025-02-03 22:14:20] WARNING:  Cannot parse result ```json
AutoBangumi     | {
AutoBangumi     |   "title_en": "The Weakest Skill 'Master of Skills' ~About the Skill Fruit That Can Be Eaten Infinitely (Death If Eaten Once)~",
AutoBangumi     |   "title_zh": "最弱技能《果实大师》～关于能无限食用技能果实（吃了就会死）这件事～",
AutoBangumi     |   "title_jp": "",
AutoBangumi     |   "season": 1,
AutoBangumi     |   "season_raw": "",
AutoBangumi     |   "episode": 1,
AutoBangumi     |   "sub": "CHT",
AutoBangumi     |   "group": "",
AutoBangumi     |   "resolution": "1080P",
AutoBangumi     |   "source": "AVC AAC"
AutoBangumi     | }
AutoBangumi     | ``` as python dict.
```