### PR TITLE
更正群晖NAS部署说明文档

### DIFF
--- a/docs/deploy/dsm.md
+++ b/docs/deploy/dsm.md
@@ -16,6 +16,8 @@
 
 点击 **项目**，然后点击 **新建**，选择 **Docker Compose**。
 
+在路径中选择 `/volume1/docker/AutoBangumi`
+
 ![new-compose](../image/dsm/new-compose.png){data-zoomable}
 
 复制以下内容填入 **Docker Compose** 中。


### PR DESCRIPTION
YAML中设置的是相对路径，需要正确选择子目录

```
    - "./config:/app/config"
     - "./data:/app/data"
```