### PR TITLE
在 `部署 > Docker Compose 部署` 页添加了 `选项3: 在 Windows 平台...``

### DIFF
--- a/docs/deploy/docker-compose.md
+++ b/docs/deploy/docker-compose.md
@@ -89,3 +89,53 @@ QB_PORT=<YOUR_PORT>
 docker compose up -d
 ```
 
+### 选项3: 在 Windows 平台，使用 Docker Desktop 部署 AutoBangumi 及 qBittorrent
+
+```yaml
+version: "3.4"
+services:
+  qbittorrent:
+    container_name: qbittorrent
+    image: superng6/qbittorrent:4.6.0_v2.0.9 # 4.6.0_v2.0.9 配置正常版本
+    hostname: qbittorrent
+    environment:
+      - PUID=1026
+      - PGID=100
+      - TZ=Asia/Shanghai
+    volumes:
+      - ./qb_config:/config
+      - ./downloads:/downloads # 注意 修改此处为自己存放动漫的目录,ab 内下载路径填写downloads
+    network_mode: bridge
+    ports:
+      - 6881:6881
+      - 6881:6881/udp
+      - 8080:8080
+    restart: unless-stopped
+
+  AutoBangumi:
+    image: "ghcr.io/estrellaxd/auto_bangumi:latest"
+    container_name: AutoBangumi
+    depends_on:
+      - qbittorrent
+    volumes:
+      - ./config:/app/config
+      - ./data:/app/data
+    network_mode: bridge
+    ports:
+      - "7892:7892"
+    dns:
+      - 223.5.5.5
+    restart: unless-stopped
+    environment:
+      - TZ=Asia/Shanghai
+      - PUID=1026
+      - PGID=100
+      - UMASK=022
+```
+
+::: warning 注意
+这里如果想通过 **桥接模式** 模式将两个容器连接起来，两个容器均需要配置为桥接模式
+:::
+
+另外，该版本的 **qbittorrent** 在首次启动 或 在未在配置文件中设置登陆密码时，会在 **Docker Desktop** 的日志文件中提示本次会话的临时密码，使用临时密码登陆系统后可以通过更改 **Web UI** 设置中的 **验证** 项固定密码，详细可见[关于新版本qBittorrent“无效的用户名和密码”，其实可以这么解决](https://zhuanlan.zhihu.com/p/685581375)，文章中演示的是群晖的部署情况，实测和 **Windows** 演示差不多。
+


### PR DESCRIPTION
由于在Windows平台部署耗费了一些精力，在配置 qbittorrent 查阅项目 issue 中翻找解决方案无果，最后通过 Linux 虚拟机下载配置文件后，折腾了一会才成功，故想在介绍文档中添加该部分教程