### PR TITLE
fix(ci): extract version number from PR title

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,14 @@ jobs:
         run: |
           if [ '${{ github.event_name }}' == 'pull_request' ]; then
             if [ ${{ github.event.pull_request.merged }} == true ]; then
-              echo "version=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+              # Extract version from PR title (handles "Release X.Y.Z", "vX.Y.Z", or "X.Y.Z")
+              PR_TITLE="${{ github.event.pull_request.title }}"
+              VERSION=$(echo "$PR_TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?' | head -1)
+              if [ -n "$VERSION" ]; then
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
+              else
+                echo "version=$PR_TITLE" >> $GITHUB_OUTPUT
+              fi
             fi
           elif [[ ${{ github.event_name }} == 'push' && (${{ github.ref }} == *'alpha'* || ${{ github.ref }} == *'beta'*) ]]; then
             echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Fix CI workflow to properly extract version numbers from PR titles.

The workflow was using the full PR title (e.g., "Release 3.2.1") as the version string, causing:
- Docker tags like `Release-3.2.1` instead of `3.2.1`
- GitHub release creation to fail (invalid tag name)

Now extracts just the version number (X.Y.Z or X.Y.Z-suffix) from PR titles, handling formats like:
- `Release 3.2.1` → `3.2.1`
- `v3.2.1` → `3.2.1`
- `3.2.1` → `3.2.1`

## Test plan

- [x] Regex extracts version correctly from various PR title formats

---

🤖 Generated with [Claude Code](https://claude.ai/code)