### PR TITLE
perf(logging): implement log rotation and limit API tail size

### DIFF
--- a/backend/src/module/conf/log.py
+++ b/backend/src/module/conf/log.py
@@ -1,4 +1,5 @@
 import logging
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 from .config import settings
@@ -25,9 +26,12 @@ def setup_logger(level: int = logging.INFO, reset: bool = False):
         datefmt=TIME_FORMAT,
         encoding="utf-8",
         handlers=[
-            logging.FileHandler(LOG_PATH, encoding="utf-8"),
+            RotatingFileHandler(
+                LOG_PATH, encoding="utf-8", maxBytes=5 * 1024 * 1024, backupCount=2
+            ),
             logging.StreamHandler(),
         ],
+        force=True,
     )
 
     # Suppress verbose HTTP request logs from httpx

--- a/backend/src/test/test_log_config.py
+++ b/backend/src/test/test_log_config.py
@@ -1,0 +1,24 @@
+import logging
+import logging.handlers
+from pathlib import Path
+from module.conf.log import setup_logger, LOG_PATH
+
+def test_log_rotation_configured():
+    """Test that the logger is configured with RotatingFileHandler."""
+    # Setup logger
+    setup_logger()
+    
+    logger = logging.getLogger()
+    # Find the file handler
+    handler = None
+    for h in logger.handlers:
+        if isinstance(h, logging.handlers.RotatingFileHandler):
+            # Check if it points to the correct file
+            # Resolve paths to ensure they match
+            if str(Path(h.baseFilename).resolve()) == str(LOG_PATH.resolve()):
+                handler = h
+                break
+    
+    assert handler is not None, "RotatingFileHandler not found for log file"
+    assert handler.maxBytes == 5 * 1024 * 1024
+    assert handler.backupCount == 2


### PR DESCRIPTION
- Replace FileHandler with RotatingFileHandler (5MB max, 2 backups) to prevent disk exhaustion
- Add force=True to logging config to ensure handler replacement
- Modify GET /log endpoint to read only last 1MB of log file for large files
- Add tests for rotation configuration and tail limit behavior

This PR tries to solve the performance issue of: https://github.com/EstrellaXD/Auto_Bangumi/issues/981