### PR TITLE
修复解析非连续更新剧集时报 AttributeError 的错误 Issue#992

### DIFF
--- a/backend/src/module/parser/analyser/raw_parser.py
+++ b/backend/src/module/parser/analyser/raw_parser.py
@@ -201,7 +201,7 @@ def process(raw_title: str):
 def raw_parser(raw: str) -> Episode | None:
     ret = process(raw)
     if ret is None:
-        logger.error(f"Parser cannot analyse {raw}")
+        logger.info(f"Detected non-episodic resource: {raw}, skipping.")
         return None
     name_en, name_zh, name_jp, season, sr, episode, sub, dpi, source, group = ret
     return Episode(

--- a/backend/src/module/parser/title_parser.py
+++ b/backend/src/module/parser/title_parser.py
@@ -68,6 +68,8 @@ class TitleParser:
                 episode = Episode(**episode_dict)
             else:
                 episode = raw_parser(raw)
+                if episode is None:
+                    return None
 
             titles = {
                 "zh": episode.title_zh,


### PR DESCRIPTION
## 背景 https://github.com/EstrellaXD/Auto_Bangumi/issues/992

当前，当 TITLE_RE 和 fallback parsing 均失败 (e.g. movie/collection resources)，raw_parser 返回 None。

在 title_parser 中，episode.title_zh 在没有 check for None 的情况下被 accessed，导致 AttributeError。

## Changes

- Add guard clause 来跳过 non-episodic resources
- Downgrade error log to info level

## Results

- movie / collection resources 等 非连续更新剧集 不再抛出异常
- 搜索结果中仍然不包含 非连续更新 剧集 (expected behavior)
- 正常剧集解析 intact