### PR TITLE
fix(database): add missing search_official_title method to BangumiDatabase

### DIFF
--- a/backend/src/module/database/bangumi.py
+++ b/backend/src/module/database/bangumi.py
@@ -390,6 +390,10 @@ class BangumiDatabase:
         logger.debug("[Database] Find bangumi id: %s.", _id)
         return bangumi
 
+    def search_official_title(self, official_title: str) -> Optional[Bangumi]:
+        statement = select(Bangumi).where(Bangumi.official_title == official_title)
+        return self.session.execute(statement).scalar_one_or_none()
+
     def search_ids(self, ids: list[int]) -> list[Bangumi]:
         """Batch lookup multiple bangumi by their IDs."""
         if not ids:


### PR DESCRIPTION
## Problem

`notification/manager.py` calls `db.bangumi.search_official_title()` inside `_get_poster()` to look up the poster image when sending notifications, but this method was never implemented in `BangumiDatabase`. This causes a crash in the rename/notification thread:

```
ERROR module.core.sub_thread:[RenameThread] Error during rename loop:
'BangumiDatabase' object has no attribute 'search_official_title'
```

The call was introduced in commit 48bf570 (`feat(notification): redesign system to support multiple providers`) but the corresponding database method was not added.

## Fix

Add `search_official_title(official_title: str) -> Optional[Bangumi]` to `BangumiDatabase` as a simple exact-match query on `Bangumi.official_title`, consistent with the existing `search_id` / `search_rss` pattern.