### PR TITLE
fix(config): align default filter regex \d+-\d to \d+-\d+

### DIFF
--- a/backend/src/module/models/config.py
+++ b/backend/src/module/models/config.py
@@ -51,7 +51,7 @@ class RSSParser(BaseModel):
     """RSS feed parsing settings."""
 
     enable: bool = Field(True, description="Enable RSS parser")
-    filter: list[str] = Field(["720", r"\d+-\d"], description="Filter")
+    filter: list[str] = Field(["720", r"\d+-\d+"], description="Filter")
     language: str = "zh"
 
 


### PR DESCRIPTION
## Problem

The global `RSSParser` default filter in `models/config.py` uses `\d+-\d` while the per-bangumi default in `models/bangumi.py` already uses `\d+-\d+`.

Both patterns are intended to filter out batch/collection torrents whose names contain an episode range like `01-13`. However `\d+-\d` (without trailing `+`) only requires the second number to be a single digit, giving subtly different and less precise matching than `\d+-\d+`.

## Fix

Change the global default from `\d+-\d` to `\d+-\d+` so both defaults are consistent.

## Impact

- Only affects **new installations** or users who have never customised the filter field (the global default is snapshotted into per-bangumi records at subscribe time).
- No breaking change.
