### PR TITLE
fix(mcp): return Response() from handle_sse to prevent NoneType error on disconnect

### DIFF
--- a/backend/src/module/mcp/server.py
+++ b/backend/src/module/mcp/server.py
@@ -15,6 +15,7 @@ from mcp.server import Server
 from mcp.server.sse import SseServerTransport
 from starlette.applications import Starlette
 from starlette.requests import Request
+from starlette.responses import Response
 from starlette.routing import Mount, Route
 
 from .resources import RESOURCE_TEMPLATES, RESOURCES, handle_resource
@@ -64,6 +65,7 @@ async def handle_sse(request: Request):
             streams[1],
             server.create_initialization_options(),
         )
+    return Response()
 
 
 def create_mcp_starlette_app() -> Starlette:


### PR DESCRIPTION
## Problem

Every time an MCP client disconnects, the following error is logged:

```
TypeError: 'NoneType' object is not callable
  File starlette/routing.py, line 76
    await response(scope, receive, send)
```

Starlette expects a route endpoint to return a callable Response. `handle_sse` had no `return` statement, so it implicitly returned `None`.

## Root Cause

The `mcp` library's `SseServerTransport` handles the SSE stream internally via `request._send`, but Starlette's routing layer still expects the endpoint to return a Response object after it completes.

The `mcp` library's own docstring in `mcp/server/sse.py` explicitly documents this requirement:

> **Note:** The handle_sse function must return a Response to avoid a "TypeError: 'NoneType' object is not callable" error when client disconnects.

## Fix

- Add `return Response()` at the end of `handle_sse`
- Import `starlette.responses.Response`

MCP functionality is unaffected — the SSE stream and all tool calls work correctly before this return.