### PR TITLE
perf: 缩小 entrypoint.sh 中 chown 范围以提升容器启动速度

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,6 @@ fi
 groupmod -o -g "${PGID}" ab
 usermod -o -u "${PUID}" ab
 
-chown ab:ab -R /app /home/ab
+chown ab:ab -R /app/data /app/config /home/ab
 
 exec su-exec "${PUID}:${PGID}" python main.py


### PR DESCRIPTION
## 修改内容
将 `entrypoint.sh` 中的 `chown` 命令从对整个 `/app` 目录递归修改，调整为仅作用于 `/app/data`、`/app/config` 和 `/home/ab` 这三个目录。

## 修改原因
缩小 `chown` 的作用范围可以减少不必要的权限修改操作。

此前对整个 `/app` 目录递归执行 `chown` 时，会包含 `/app/.venv`，而该目录文件数量较多，递归修改权限需要较长时间。

该优化可以减少容器启动时的开销，在 issue #969 提到的性能较弱设备（例如 TrueNAS）上效果明显。

## 相关 Issue
#969