### PR TITLE
Fix:修复程序启动时与qBittorrent链接的SSL不遵循config设置的bug

### DIFF
--- a/backend/src/module/checker/checker.py
+++ b/backend/src/module/checker/checker.py
@@ -66,7 +66,7 @@ class Checker:
             return True
 
         try:
-            prefix =  "http" if settings.downloader.ssl else "https"
+            prefix =  "https" if settings.downloader.ssl else "http"
             url = (
                 f"{prefix}://{settings.downloader.host}"
                 if "://" not in settings.downloader.host

--- a/backend/src/module/checker/checker.py
+++ b/backend/src/module/checker/checker.py
@@ -66,8 +66,9 @@ class Checker:
             return True
 
         try:
+            prefix =  "http" if settings.downloader.ssl else "https"
             url = (
-                f"http://{settings.downloader.host}"
+                f"{prefix}://{settings.downloader.host}"
                 if "://" not in settings.downloader.host
                 else f"{settings.downloader.host}"
             )


### PR DESCRIPTION
程序启动时会进行十次http链接,当面对重定向至https(443端口)的url时,会直接报错进而使程序延迟五分钟启动

本补丁令程序启动时的探活也遵从config中的SSL设置,防止重定向至https的url在启动时不可用