### PR TITLE
fix(qb_downloader): accept HTTP 204 as login success for qBittorrent v5.x

### DIFF
--- a/backend/src/module/downloader/client/qb_downloader.py
+++ b/backend/src/module/downloader/client/qb_downloader.py
@@ -37,7 +37,7 @@ class QbDownloader:
                     self._url("auth/login"),
                     data={"username": self.username, "password": self.password},
                 )
-                if resp.status_code == 200 and resp.text == "Ok.":
+                if resp.status_code in (200, 204):
                     return True
                 elif resp.status_code == 403:
                     logger.error("Login refused by qBittorrent Server")


### PR DESCRIPTION
## Problem

AutoBangumi 3.2.6 cannot login to qBittorrent v5.x. The login keeps failing with `Can't login qBittorrent Server`.

## Root Cause

### qBittorrent source evidence

**1. `authcontroller.cpp` — login returns no data body:**

https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/api/authcontroller.cpp#L43-L57

```cpp
void AuthController::loginAction()
{
    if (m_sessionManager->session())
    {
        setStatus(APIStatus::Ok);  // <-- only sets status, NO setResult()
        return;
    }

    if (m_sessionManager->validateCredentials(params[u"username"_s], params[u"password"_s]))
    {
        m_sessionManager->sessionStart();
        setStatus(APIStatus::Ok);  // <-- only sets status, NO setResult()
    }
    else
    {
        throw APIError(APIErrorType::Unauthorized);
    }
}
```

The login action only calls `setStatus()` — it never calls `setResult()`. So the API result has **no data payload**.

**2. `webapplication.cpp` — no data = HTTP 204:**

https://github.com/qbittorrent/qBittorrent/blob/master/src/webui/webapplication.cpp#L402-L406

```cpp
const auto result = std::get<RegularAPIResult>(apiResult);
if (result.data.isNull())
{
    response.status = {.code = 204};  // <-- login hits this branch
}
else
{
    switch (result.status)
    {
    case APIStatus::Async:
        response.status = {.code = 202};
        break;
    case APIStatus::Ok:
        response.status = {.code = 200};  // <-- only when data IS present
        break;
    }
}
```

Because login returns no data (`result.data.isNull()` is true), the response is **HTTP 204 No Content**. HTTP 200 is only used when an endpoint both succeeds **and** returns data.

### AutoBangumi check

https://github.com/EstrellaXD/Auto_Bangumi/blob/main/backend/src/module/downloader/client/qb_downloader.py#L40

```python
if resp.status_code == 200 and resp.text == "Ok.":
```

This check expects HTTP 200 + body "Ok.", which was the older qBittorrent behavior before the web API refactor. Current qBittorrent returns HTTP 204 + empty body for login.

## Verified

```bash
$ curl -sv -X POST http://127.0.0.1:18080/api/v2/auth/login \
  -d 'username=admin&password=xxx'
< HTTP/1.1 204 OK
< set-cookie: QBT_SID_18080=xxx...
(empty body)
```

Tested with qBittorrent v5.2.1.10.

## Fix

Accept both 200 and 204 as valid login responses:

```python
if resp.status_code in (200, 204):
```

The session cookie is still set via `Set-Cookie` header regardless of 200 vs 204 status, so no other changes are needed.