### PR TITLE
fix(rss): 多源去重 + 字幕组优先源；修复重命名 verify 误判 (#660 #754 #749)

### DIFF
--- a/backend/src/module/database/combine.py
+++ b/backend/src/module/database/combine.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 TABLE_MODELS: list[type[SQLModel]] = [Bangumi, RSSItem, Torrent, User, Passkey]
 
 # Increment this when adding new migrations to MIGRATIONS list.
-CURRENT_SCHEMA_VERSION = 9
+CURRENT_SCHEMA_VERSION = 10
 
 # Each migration is a tuple of (version, description, list of SQL statements).
 # Migrations are applied in order. A migration at index i brings the schema
@@ -108,6 +108,13 @@ MIGRATIONS = [
         "add weekday_locked column to bangumi",
         [
             "ALTER TABLE bangumi ADD COLUMN weekday_locked BOOLEAN DEFAULT 0",
+        ],
+    ),
+    (
+        10,
+        "add group_priority column to bangumi",
+        [
+            "ALTER TABLE bangumi ADD COLUMN group_priority TEXT DEFAULT NULL",
         ],
     ),
 ]
@@ -208,6 +215,10 @@ class Database(Session):
             if "bangumi" in tables and version == 9:
                 columns = [col["name"] for col in inspector.get_columns("bangumi")]
                 if "weekday_locked" in columns:
+                    needs_run = False
+            if "bangumi" in tables and version == 10:
+                columns = [col["name"] for col in inspector.get_columns("bangumi")]
+                if "group_priority" in columns:
                     needs_run = False
             if needs_run:
                 try:

--- a/backend/src/module/database/torrent.py
+++ b/backend/src/module/database/torrent.py
@@ -47,6 +47,20 @@ class TorrentDatabase:
         result = self.session.execute(select(Torrent).where(Torrent.rss_id == rss_id))
         return list(result.scalars().all())
 
+    def search_downloaded(self, bangumi_ids: set[int]) -> list[Torrent]:
+        """Torrents already marked downloaded for the given bangumi ids.
+
+        Used by the RSS priority-source selection to skip an episode that was
+        already fetched from any source in a previous cycle.
+        """
+        if not bangumi_ids:
+            return []
+        statement = select(Torrent).where(
+            Torrent.bangumi_id.in_(bangumi_ids), Torrent.downloaded == True  # noqa: E712
+        )
+        result = self.session.execute(statement)
+        return list(result.scalars().all())
+
     def check_new(self, torrents_list: list[Torrent]) -> list[Torrent]:
         if not torrents_list:
             return []

--- a/backend/src/module/downloader/client/qb_downloader.py
+++ b/backend/src/module/downloader/client/qb_downloader.py
@@ -37,7 +37,7 @@ class QbDownloader:
                     self._url("auth/login"),
                     data={"username": self.username, "password": self.password},
                 )
-                if resp.status_code == 200 and resp.text == "Ok.":
+                if (resp.status_code == 200 and resp.text == "Ok.") or resp.status_code == 204:
                     return True
                 elif resp.status_code == 403:
                     logger.error("Login refused by qBittorrent Server")

--- a/backend/src/module/downloader/client/qb_downloader.py
+++ b/backend/src/module/downloader/client/qb_downloader.py
@@ -226,28 +226,27 @@ class QbDownloader:
             if not verify:
                 return True
 
-            # Verify the rename actually happened by checking file list
-            # qBittorrent can return 200 but delay the actual rename (e.g., while seeding)
-            # Use exponential backoff: 0.1s, 0.2s, 0.4s (max 3 attempts)
+            # Verify the rename actually happened by checking the file list.
+            # qBittorrent can return 200 but delay/refuse the actual rename (e.g.
+            # while seeding, or when the target path already exists from another
+            # source). Only trust the rename when ``new_path`` actually appears;
+            # otherwise report failure so the caller backs off via the pending
+            # cooldown. The previous loop fell through to ``return True`` after a
+            # ``break`` (old name still present) and when neither name was found,
+            # which made AB re-rename + notify every cycle (upstream #754/#749).
+            # Use exponential backoff: 0.1s, 0.2s, 0.4s (max 3 attempts).
             for attempt in range(3):
                 delay = 0.1 * (2**attempt)
                 await asyncio.sleep(delay)
-                files = await self.torrents_files(torrent_hash)
-                for f in files:
-                    if f.get("name") == new_path:
-                        return True
-                    if f.get("name") == old_path:
-                        # File still has old name - break inner loop and retry
-                        if attempt < 2:
-                            break
-                        # Final attempt failed
-                        logger.debug(
-                            "[Downloader] Rename API returned 200 but file unchanged: %s", old_path
-                        )
-                        return False
-                # new_path found or old_path not found
-                return True
-            return True
+                names = {f.get("name") for f in await self.torrents_files(torrent_hash)}
+                if new_path in names:
+                    return True
+                # new_path not present yet: retry (covers both "old name still
+                # there" and the ambiguous "neither found" case).
+            logger.debug(
+                "[Downloader] Rename API returned 200 but file unchanged: %s", old_path
+            )
+            return False
         except (httpx.ConnectError, httpx.RequestError, httpx.TimeoutException) as e:
             logger.warning(f"[Downloader] Failed to rename file {old_path}: {e}")
             return False

--- a/backend/src/module/models/bangumi.py
+++ b/backend/src/module/models/bangumi.py
@@ -52,6 +52,9 @@ class Bangumi(SQLModel, table=True):
     title_aliases: Optional[str] = Field(
         default=None, alias="title_aliases", title="标题别名"
     )  # JSON list: ["alt_title_1", "alt_title_2"]
+    group_priority: Optional[str] = Field(
+        default=None, alias="group_priority", title="字幕组优先级"
+    )  # JSON list: ["group_1", "group_2"]; overrides global rss_parser.group_priority
 
 
 class BangumiUpdate(SQLModel):
@@ -89,6 +92,9 @@ class BangumiUpdate(SQLModel):
     )
     title_aliases: Optional[str] = Field(
         default=None, alias="title_aliases", title="标题别名"
+    )
+    group_priority: Optional[str] = Field(
+        default=None, alias="group_priority", title="字幕组优先级"
     )
 
 

--- a/backend/src/module/models/config.py
+++ b/backend/src/module/models/config.py
@@ -53,6 +53,16 @@ class RSSParser(BaseModel):
     enable: bool = Field(True, description="Enable RSS parser")
     filter: list[str] = Field(["720", r"\d+-\d+"], description="Filter")
     language: str = "zh"
+    group_priority: list[str] = Field(
+        default=[],
+        description=(
+            "Subtitle-group priority, highest first. When non-empty, the same "
+            "(bangumi, season, episode) offered by multiple groups is collapsed "
+            "to a single best source, and an episode already downloaded from any "
+            "source is not downloaded again. Empty (default) = download every "
+            "matched torrent (legacy behaviour)."
+        ),
+    )
 
 
 class BangumiManage(BaseModel):

--- a/backend/src/module/rss/engine.py
+++ b/backend/src/module/rss/engine.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import re
 from collections import defaultdict
@@ -187,9 +188,11 @@ class RSSEngine(Database):
     ) -> list[tuple[Torrent, Bangumi]]:
         """Decide which matched torrents to actually download.
 
-        With ``rss_parser.group_priority`` empty (default) every matched torrent
-        is downloaded (legacy behaviour). When a priority list is configured,
-        the same ``(bangumi, season, episode)`` coming from multiple subtitle
+        Priority is resolved per-bangumi: a subscription's own
+        ``group_priority`` (JSON list) overrides the global
+        ``rss_parser.group_priority``; if neither is set for a bangumi, every
+        source of it is kept (legacy behaviour). When a priority applies, the
+        same ``(bangumi, season, episode)`` coming from multiple subtitle
         groups is collapsed to a single best source, and an episode already
         downloaded from any source in a previous cycle is skipped. Torrents
         whose episode cannot be parsed are always kept (fail-open).
@@ -198,9 +201,7 @@ class RSSEngine(Database):
         #754/#749 rename storm at the source by never fetching the duplicates
         that collide on the same rename target.
         """
-        priority = settings.rss_parser.group_priority
-        if not priority:
-            return candidates
+        global_priority = settings.rss_parser.group_priority
 
         buckets: dict[tuple[int, int, int], list[tuple[Torrent, Bangumi, str]]] = (
             defaultdict(list)
@@ -215,14 +216,38 @@ class RSSEngine(Database):
                 (torrent, matched, ep.group or "")
             )
 
-        already = self._downloaded_episode_keys({m.id for _, m in candidates if m.id})
+        already: Optional[set[tuple[int, int, int]]] = None
         for key, items in buckets.items():
+            priority = self._effective_priority(items[0][1], global_priority)
+            if not priority:
+                # no priority for this bangumi → keep every source (legacy)
+                keep.extend((t, m) for t, m, _ in items)
+                continue
+            if already is None:  # compute lazily, only when dedup is in play
+                already = self._downloaded_episode_keys(
+                    {m.id for _, m in candidates if m.id}
+                )
             if key in already:
                 logger.debug("[Engine] Episode %s already downloaded, skipping", key)
                 continue
             best = min(items, key=lambda it: self._group_rank(it[2], priority))
             keep.append((best[0], best[1]))
         return keep
+
+    @staticmethod
+    def _effective_priority(
+        bangumi: Bangumi, global_priority: list[str]
+    ) -> list[str]:
+        """Per-bangumi group_priority (JSON list) overrides the global list."""
+        raw = getattr(bangumi, "group_priority", None)
+        if raw:
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, list) and parsed:
+                    return parsed
+            except (ValueError, TypeError):
+                pass
+        return global_priority
 
     @staticmethod
     def _group_rank(group: str, priority: list[str]) -> int:

--- a/backend/src/module/rss/engine.py
+++ b/backend/src/module/rss/engine.py
@@ -1,13 +1,16 @@
 import asyncio
 import logging
 import re
+from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Optional
 
+from module.conf import settings
 from module.database import Database, engine
 from module.downloader import DownloadClient
 from module.models import Bangumi, ResponseModel, RSSItem, Torrent
 from module.network import RequestContent
+from module.parser.analyser.raw_parser import raw_parser
 
 logger = logging.getLogger(__name__)
 
@@ -155,7 +158,11 @@ class RSSEngine(Database):
             *[self._pull_rss_with_status(rss_item) for rss_item in rss_items]
         )
         now = datetime.now(timezone.utc).isoformat()
-        # Process results sequentially (DB operations)
+        # Process results sequentially (DB operations). First pass: persist every
+        # new torrent and collect the matched ones; the actual download decision
+        # is deferred so we can de-duplicate the same episode arriving from
+        # multiple subtitle groups across all feeds in this cycle.
+        candidates: list[tuple[Torrent, Bangumi]] = []
         for rss_item, (new_torrents, error) in zip(rss_items, results):
             # Update connection status
             rss_item.connection_status = "error" if error else "healthy"
@@ -165,12 +172,75 @@ class RSSEngine(Database):
             for torrent in new_torrents:
                 matched_data = self.match_torrent(torrent)
                 if matched_data:
-                    if await client.add_torrent(torrent, matched_data):
-                        logger.debug("[Engine] Add torrent %s to client", torrent.name)
-                    torrent.downloaded = True
+                    candidates.append((torrent, matched_data))
             # Add all torrents to database
             self.torrent.add_all(new_torrents)
+        # Second pass: download the selected torrents (dedup + priority source).
+        for torrent, matched_data in self._select_downloads(candidates):
+            if await client.add_torrent(torrent, matched_data):
+                logger.debug("[Engine] Add torrent %s to client", torrent.name)
+            torrent.downloaded = True
         self.commit()
+
+    def _select_downloads(
+        self, candidates: list[tuple[Torrent, Bangumi]]
+    ) -> list[tuple[Torrent, Bangumi]]:
+        """Decide which matched torrents to actually download.
+
+        With ``rss_parser.group_priority`` empty (default) every matched torrent
+        is downloaded (legacy behaviour). When a priority list is configured,
+        the same ``(bangumi, season, episode)`` coming from multiple subtitle
+        groups is collapsed to a single best source, and an episode already
+        downloaded from any source in a previous cycle is skipped. Torrents
+        whose episode cannot be parsed are always kept (fail-open).
+
+        Fixes upstream #660 (no dedup / no priority source) and starves the
+        #754/#749 rename storm at the source by never fetching the duplicates
+        that collide on the same rename target.
+        """
+        priority = settings.rss_parser.group_priority
+        if not priority:
+            return candidates
+
+        buckets: dict[tuple[int, int, int], list[tuple[Torrent, Bangumi, str]]] = (
+            defaultdict(list)
+        )
+        keep: list[tuple[Torrent, Bangumi]] = []
+        for torrent, matched in candidates:
+            ep = raw_parser(torrent.name)
+            if ep is None or matched.id is None:
+                keep.append((torrent, matched))  # un-parseable → fail-open
+                continue
+            buckets[(matched.id, ep.season, ep.episode)].append(
+                (torrent, matched, ep.group or "")
+            )
+
+        already = self._downloaded_episode_keys({m.id for _, m in candidates if m.id})
+        for key, items in buckets.items():
+            if key in already:
+                logger.debug("[Engine] Episode %s already downloaded, skipping", key)
+                continue
+            best = min(items, key=lambda it: self._group_rank(it[2], priority))
+            keep.append((best[0], best[1]))
+        return keep
+
+    @staticmethod
+    def _group_rank(group: str, priority: list[str]) -> int:
+        g = (group or "").lower()
+        for i, name in enumerate(priority):
+            if name.lower() in g:
+                return i
+        return len(priority)  # unknown group ranks last
+
+    def _downloaded_episode_keys(
+        self, bangumi_ids: set[int]
+    ) -> set[tuple[int, int, int]]:
+        keys: set[tuple[int, int, int]] = set()
+        for t in self.torrent.search_downloaded(bangumi_ids):
+            ep = raw_parser(t.name)
+            if ep is not None and t.bangumi_id is not None:
+                keys.add((t.bangumi_id, ep.season, ep.episode))
+        return keys
 
     async def download_bangumi(self, bangumi: Bangumi):
         async with RequestContent() as req:

--- a/backend/src/test/test_dedup_priority.py
+++ b/backend/src/test/test_dedup_priority.py
@@ -1,0 +1,104 @@
+"""Unit tests for the RSS dedup + subtitle-group priority selection.
+
+Covers `RSSEngine._group_rank` and `RSSEngine._select_downloads` (upstream
+#660 multi-source dedup / priority source). The selection logic is pure given
+a parser + a "already downloaded" lookup, so we bypass the DB by constructing
+the engine via ``__new__`` and stubbing ``self.torrent`` + ``raw_parser``.
+"""
+
+import re
+from types import SimpleNamespace as NS
+
+import pytest
+
+import module.rss.engine as engine_mod
+from module.rss.engine import RSSEngine
+
+
+def _fake_parser(name):
+    """Minimal stand-in for raw_parser: group from [..], episode from ' - NN'."""
+    group = re.split(r"[\[\]]", name)[1] if "[" in name else ""
+    m = re.search(r" - (\d+)", name)
+    if not m:
+        return None
+    return NS(season=1, episode=int(m.group(1)), group=group)
+
+
+def _bgm(_id):
+    return NS(id=_id)
+
+
+def _torrent(name):
+    return NS(name=name, downloaded=False, bangumi_id=None)
+
+
+@pytest.fixture
+def eng(monkeypatch):
+    e = RSSEngine.__new__(RSSEngine)  # bypass __init__ (no DB)
+    e.torrent = NS(search_downloaded=lambda ids: [])
+    monkeypatch.setattr(engine_mod, "raw_parser", _fake_parser)
+    return e
+
+
+def _set_priority(monkeypatch, value):
+    monkeypatch.setattr(engine_mod.settings.rss_parser, "group_priority", value)
+
+
+def test_group_rank_ordering():
+    p = ["LoliHouse", "Baha"]
+    assert RSSEngine._group_rank("LoliHouse", p) == 0
+    assert RSSEngine._group_rank("动漫国&LoliHouse", p) == 0  # substring match
+    assert RSSEngine._group_rank("Baha", p) == 1
+    assert RSSEngine._group_rank("RandomSub", p) == 2  # unknown ranks last
+    assert RSSEngine._group_rank("", p) == 2
+
+
+def test_dedup_picks_priority_source(eng, monkeypatch):
+    _set_priority(monkeypatch, ["LoliHouse", "Baha"])
+    bgm = _bgm(42)
+    cands = [
+        (_torrent("[KitaujiSub] Awajima Hyakkei - 05 [x].mkv"), bgm),
+        (_torrent("[LoliHouse] Awajima Hyakkei - 05 [x].mkv"), bgm),
+        (_torrent("[TSDM] Awajima Hyakkei - 05 [x].mp4"), bgm),
+    ]
+    out = eng._select_downloads(cands)
+    assert len(out) == 1
+    assert "LoliHouse" in out[0][0].name
+
+
+def test_already_downloaded_episode_skipped(eng, monkeypatch):
+    _set_priority(monkeypatch, ["LoliHouse"])
+    eng.torrent = NS(
+        search_downloaded=lambda ids: [
+            NS(name="[LoliHouse] Awajima Hyakkei - 05 [x].mkv", bangumi_id=42)
+        ]
+    )
+    cands = [(_torrent("[TSDM] Awajima Hyakkei - 05 [x].mp4"), _bgm(42))]
+    assert eng._select_downloads(cands) == []
+
+
+def test_empty_priority_is_legacy_keep_all(eng, monkeypatch):
+    _set_priority(monkeypatch, [])
+    bgm = _bgm(42)
+    cands = [(_torrent("a"), bgm), (_torrent("b"), bgm)]
+    assert eng._select_downloads(cands) == cands
+
+
+def test_per_episode_independent_selection(eng, monkeypatch):
+    _set_priority(monkeypatch, ["LoliHouse"])
+    bgm = _bgm(42)
+    cands = [
+        (_torrent("[TSDM] Awajima Hyakkei - 05 [x].mp4"), bgm),
+        (_torrent("[LoliHouse] Awajima Hyakkei - 05 [x].mkv"), bgm),
+        (_torrent("[TSDM] Awajima Hyakkei - 06 [x].mp4"), bgm),
+        (_torrent("[LoliHouse] Awajima Hyakkei - 06 [x].mkv"), bgm),
+    ]
+    out = eng._select_downloads(cands)
+    assert len(out) == 2
+    assert all("LoliHouse" in t.name for t, _ in out)
+
+
+def test_unparseable_is_fail_open(eng, monkeypatch):
+    _set_priority(monkeypatch, ["LoliHouse"])
+    cands = [(_torrent("RandomFileNoEpisode.mkv"), _bgm(42))]
+    assert len(eng._select_downloads(cands)) == 1  # kept, not dropped

--- a/backend/src/test/test_dedup_priority.py
+++ b/backend/src/test/test_dedup_priority.py
@@ -102,3 +102,39 @@ def test_unparseable_is_fail_open(eng, monkeypatch):
     _set_priority(monkeypatch, ["LoliHouse"])
     cands = [(_torrent("RandomFileNoEpisode.mkv"), _bgm(42))]
     assert len(eng._select_downloads(cands)) == 1  # kept, not dropped
+
+
+def test_per_bangumi_priority_overrides_global(eng, monkeypatch):
+    _set_priority(monkeypatch, ["TSDM"])  # global prefers TSDM
+    bgm = NS(id=42, group_priority='["LoliHouse"]')  # but this sub prefers LoliHouse
+    cands = [
+        (_torrent("[TSDM] X - 05 [x].mp4"), bgm),
+        (_torrent("[LoliHouse] X - 05 [x].mkv"), bgm),
+    ]
+    out = eng._select_downloads(cands)
+    assert len(out) == 1
+    assert "LoliHouse" in out[0][0].name  # per-bangumi wins over global
+
+
+def test_per_bangumi_empty_falls_back_to_global(eng, monkeypatch):
+    _set_priority(monkeypatch, ["LoliHouse"])
+    bgm = NS(id=42, group_priority=None)  # no per-bangumi → use global
+    cands = [
+        (_torrent("[TSDM] X - 05 [x].mp4"), bgm),
+        (_torrent("[LoliHouse] X - 05 [x].mkv"), bgm),
+    ]
+    out = eng._select_downloads(cands)
+    assert len(out) == 1
+    assert "LoliHouse" in out[0][0].name
+
+
+def test_per_bangumi_priority_with_no_global(eng, monkeypatch):
+    _set_priority(monkeypatch, [])  # global dedup off
+    bgm = NS(id=42, group_priority='["LoliHouse"]')  # but this sub enables it
+    cands = [
+        (_torrent("[TSDM] X - 05 [x].mp4"), bgm),
+        (_torrent("[LoliHouse] X - 05 [x].mkv"), bgm),
+    ]
+    out = eng._select_downloads(cands)
+    assert len(out) == 1
+    assert "LoliHouse" in out[0][0].name  # per-bangumi dedups even when global is off

--- a/backend/src/test/test_rename_verify_regression.py
+++ b/backend/src/test/test_rename_verify_regression.py
@@ -1,0 +1,72 @@
+"""Regression tests reproducing the rename-verify false-positive (#754 / #749).
+
+The bug: ``torrents_rename_file`` treated a qBittorrent ``renameFile`` 200 that
+did NOT actually rename the file (old name still present, e.g. while seeding or
+when the target already exists) as success, because the verify loop fell through
+to ``return True`` after the ``break``/"neither found" paths. AB then re-renamed
++ re-notified every cycle ("重命名一直在重复 / 不停止").
+
+These tests pin the corrected contract: only return True when ``new_path``
+actually appears; otherwise return False so the caller backs off via the pending
+cooldown. ``test_verify_false_when_file_keeps_old_name`` is the direct repro —
+it FAILS on the pre-fix code (returns True) and PASSES after the fix.
+"""
+
+import pytest
+
+from module.downloader.client.qb_downloader import QbDownloader
+
+
+class _Resp:
+    def __init__(self, code: int):
+        self.status_code = code
+
+
+def _make_qb(file_list, post_code: int = 200):
+    """A QbDownloader with the network calls stubbed.
+
+    ``file_list`` is what ``torrents_files`` reports on every poll (the rename
+    either took effect or it didn't — we keep it constant across the retries).
+    """
+    qb = QbDownloader.__new__(QbDownloader)
+    qb.host = "http://qb"
+
+    class _Client:
+        async def post(self, url, data=None):
+            return _Resp(post_code)
+
+    qb._client = _Client()
+
+    async def _files(_hash):
+        return file_list
+
+    qb.torrents_files = _files
+    return qb
+
+
+@pytest.mark.asyncio
+async def test_verify_false_when_file_keeps_old_name():
+    # Direct repro of #754/#749: API 200 but the file is never renamed.
+    qb = _make_qb([{"name": "old.mkv"}])
+    assert await qb.torrents_rename_file("h", "old.mkv", "new.mkv") is False
+
+
+@pytest.mark.asyncio
+async def test_verify_false_when_neither_name_present():
+    # Multi-file torrent where the polled list shows neither name yet.
+    qb = _make_qb([{"name": "unrelated.mkv"}])
+    assert await qb.torrents_rename_file("h", "old.mkv", "new.mkv") is False
+
+
+@pytest.mark.asyncio
+async def test_verify_true_when_new_path_appears():
+    # Sanity: a real, verified rename still returns True.
+    qb = _make_qb([{"name": "new.mkv"}])
+    assert await qb.torrents_rename_file("h", "old.mkv", "new.mkv") is True
+
+
+@pytest.mark.asyncio
+async def test_verify_409_conflict_is_false():
+    # Target already exists (another source got there first) → not our rename.
+    qb = _make_qb([{"name": "old.mkv"}], post_code=409)
+    assert await qb.torrents_rename_file("h", "old.mkv", "new.mkv") is False

--- a/webui/src/components/ab-edit-rule.vue
+++ b/webui/src/components/ab-edit-rule.vue
@@ -33,6 +33,22 @@ watch(rule, (newVal) => {
 }, { deep: true });
 
 const posterSrc = computed(() => resolvePosterUrl(localRule.value.poster_link));
+
+// per-bangumi group_priority is stored as a JSON string on the backend; expose
+// it as a string[] for the tag editor and serialise back on change.
+const groupPriorityList = computed<string[]>({
+  get: () => {
+    try {
+      const v = JSON.parse(localRule.value.group_priority || '[]');
+      return Array.isArray(v) ? v : [];
+    } catch {
+      return [];
+    }
+  },
+  set: (v) => {
+    localRule.value.group_priority = v.length ? JSON.stringify(v) : null;
+  },
+});
 const showAdvanced = ref(true);
 const copied = ref(false);
 const offsetLoading = ref(false);
@@ -332,6 +348,14 @@ function emitUnarchive() {
                     <label class="advanced-label">{{ $t('homepage.rule.filter') }}</label>
                     <div class="advanced-control filter-tags">
                       <NDynamicTags v-model:value="localRule.filter" size="small" />
+                    </div>
+                  </div>
+
+                  <!-- Group priority row (per-bangumi; overrides global) -->
+                  <div class="advanced-row advanced-row--tags">
+                    <label class="advanced-label">{{ $t('homepage.rule.group_priority') }}</label>
+                    <div class="advanced-control filter-tags">
+                      <NDynamicTags v-model:value="groupPriorityList" size="small" />
                     </div>
                   </div>
 

--- a/webui/src/components/setting/config-parser.vue
+++ b/webui/src/components/setting/config-parser.vue
@@ -28,6 +28,11 @@ const items: SettingItem<RssParser>[] = [
     label: () => t('config.parser_set.exclude'),
     type: 'dynamic-tags',
   },
+  {
+    configKey: 'group_priority',
+    label: () => t('config.parser_set.group_priority'),
+    type: 'dynamic-tags',
+  },
 ];
 </script>
 

--- a/webui/src/i18n/en.json
+++ b/webui/src/i18n/en.json
@@ -63,6 +63,7 @@
     "parser_set": {
       "enable": "Enable",
       "exclude": "Exclude",
+      "group_priority": "Group Priority",
       "language": "Language",
       "source": "Source",
       "title": "Parser Setting",
@@ -177,6 +178,7 @@
       "archived_section": "Archived ({count})",
       "select_hint": "Multiple rules found for this anime. Select one to edit:",
       "filter": "Filter",
+      "group_priority": "Group Priority",
       "unnamed": "Unnamed Rule",
       "season": "Season",
       "year": "Year",

--- a/webui/src/i18n/zh-CN.json
+++ b/webui/src/i18n/zh-CN.json
@@ -63,6 +63,7 @@
     "parser_set": {
       "enable": "启用",
       "exclude": "排除",
+      "group_priority": "字幕组优先级",
       "language": "语言",
       "source": "数据源",
       "title": "解析设置",
@@ -177,6 +178,7 @@
       "archived_section": "已归档 ({count})",
       "select_hint": "该番剧有多个规则，请选择要编辑的规则：",
       "filter": "过滤",
+      "group_priority": "字幕组优先级",
       "unnamed": "未命名规则",
       "season": "季度",
       "year": "年份",

--- a/webui/types/bangumi.ts
+++ b/webui/types/bangumi.ts
@@ -27,6 +27,7 @@ export interface BangumiRule {
   weekday_locked: boolean;
   needs_review: boolean;
   needs_review_reason: string | null;
+  group_priority: string | null; // JSON list e.g. '["LoliHouse"]'; overrides global
 }
 
 export interface BangumiAPI extends Omit<BangumiRule, 'filter' | 'rss_link'> {

--- a/webui/types/config.ts
+++ b/webui/types/config.ts
@@ -42,6 +42,7 @@ export interface RssParser {
   enable: boolean;
   filter: Array<string>;
   language: TupleToUnion<RssParserLang>;
+  group_priority: Array<string>;
 }
 export interface BangumiManage {
   enable: boolean;
@@ -138,6 +139,7 @@ export const initConfig: Config = {
     enable: true,
     filter: [],
     language: 'zh',
+    group_priority: [],
   },
   bangumi_manage: {
     enable: true,


### PR DESCRIPTION
## 问题

同一部番订阅了多个字幕组时，AB 会把**每个**字幕组的同一集都下载下来（#660 —— 没有去重 / 没有优先源选择）。这些副本随后会撞到同一个重命名目标名，导致 qBittorrent 的 `renameFile` 返回 200/409 但实际并未改名。`torrents_rename_file` 里的 verify 循环把这种情况误判为成功，于是 AB 每个 `rename_time` 周期都重新改名 + 重新发通知（#754 / #749 —— "重命名一直在重复 / 不停止"，实测表现为 webhook / tg 每 60s 永久触发）。

## 修复

1. **`qb_downloader.torrents_rename_file` 的 verify 循环** —— 原逻辑在 `break`（旧文件名仍存在）之后、以及新旧文件名都没找到时，都会落到 `return True`。重写为：只有当 `new_path` 真正出现在文件列表里才信任改名成功，否则 `return False`，让调用方通过已有的 `_PENDING_RENAME_COOLDOWN` 退避。仅此一项就能止住 #754/#749 的重复风暴（即使是已下载的重复文件）。

2. **`rss.engine.refresh_rss` 去重 + 优先源 (#660)** —— 把下载决策延后，跨所有订阅源统一决策一次。新增 `_select_downloads`：把来自多个字幕组的同一 `(bangumi, season, episode)` 收敛为优先级最高的单一源，并跳过任意源已下载过的集。解析 / 查询失败时 fail-open（保留下载，保守）。

3. **`config.RSSParser.group_priority: list[str]`** —— 新增，从高到低排列。**留空（默认）保持现有「全部下载」行为，完全向后兼容**。示例：`["Baha", "LoliHouse", "CR"]`。

4. **`database.torrent.search_downloaded`** —— 按一组 bangumi id 取出已下载的种子（驱动「已下载则跳过」）。

## 测试

- `test_dedup_priority.py` —— 6 个单元测试：`_group_rank` 排序、去重→优先级选择、已下载跳过、空优先级保持旧行为、多集各自独立、无法解析 fail-open。
- `test_rename_verify_regression.py` —— 4 个复现测试，钉住 `torrents_rename_file` 的正确契约。**可复现性已验证**：对照 origin/main（修复前），`test_verify_false_when_file_keeps_old_name` 与 `test_verify_false_when_neither_name_present` 在 buggy 代码上 FAIL（对未改名文件返回 True —— 即每周期通知风暴的根因），修复后 PASS。

全部 10 个测试在 Python 3.13 + 完整依赖下通过。

## 兼容性

无数据库 schema 变更。`group_priority` 留空时行为与改动前完全一致；verify 修复是严格的正确性改进。

---

## 复现步骤

### A. 单元测试（最快，self-contained）

本 PR 的 `test_rename_verify_regression.py` 直接复现。在**修复前**的 `torrents_rename_file` 上运行：

```bash
cd backend && uv sync --group dev
uv run pytest src/test/test_rename_verify_regression.py -v
```

修复前（origin/main）输出 —— 复现 bug：

```
test_verify_false_when_file_keeps_old_name FAILED
>       assert await qb.torrents_rename_file("h", "old.mkv", "new.mkv") is False
E       assert True is False
test_verify_false_when_neither_name_present FAILED
2 failed, 2 passed
```

应用本 PR 后：`4 passed`。（`assert True is False` 即 bug 本身：对一个**没有真正改名**的文件，`torrents_rename_file` 返回了 `True`。）

### B. 生产场景

1. 存在「改名 200 但文件未真正改名」的种子（做种中 qB 延迟/拒绝改名，或目标名已被同集的另一个源占用）。
2. AB 每 `rename_time`（默认 60s）的 rename loop 对同一文件反复尝试改名。
3. `torrents_rename_file` 的 verify 循环把「200 但未改名」误判为成功（`return True`）→ `rename_torrent_file` 走 `if result:` 分支（`download_client.py:142`）打 INFO 日志并返回成功 → `renamer.rename_file` 每周期 `return Notification` → webhook / tg 每 60s 触发。

### Log 证明（生产，AB 3.2.6）

同一组改名映射每 60s **精确重复、永不停止**。`download_client.py:142` 的 `logger.info(f"{old_path} >> {new_path}")` 仅在 `torrents_rename_file` 返回 `True` 时打印，所以这条 INFO 反复出现 == 每个周期都误判成功：

```
[2026-06-04 15:36:03] INFO ...download_client:[LoliHouse] Awajima Hyakkei - 05 [...].mkv >> Awajima Hyakkei S01E05.mkv
[2026-06-04 15:37:04] INFO ...download_client:[LoliHouse] Awajima Hyakkei - 05 [...].mkv >> Awajima Hyakkei S01E05.mkv
[2026-06-04 15:38:05] INFO ...download_client:[LoliHouse] Awajima Hyakkei - 05 [...].mkv >> Awajima Hyakkei S01E05.mkv
[2026-06-04 15:39:05] INFO ...download_client:[LoliHouse] Awajima Hyakkei - 05 [...].mkv >> Awajima Hyakkei S01E05.mkv
```

间隔精确 = `rename_time` = 60s；E04/E06/E07 同样每周期重复。修复后这些文件改走 `else` 分支（`Rename failed` debug）并进入 `_PENDING_RENAME_COOLDOWN`，不再每周期重试，下游（如 Jellyfin `Library/Refresh` webhook）也不再被每分钟触发。