### PR TITLE
fix: torrents_rename_file verify loop never retries + None guard

### DIFF
--- a/backend/src/module/downloader/client/qb_downloader.py
+++ b/backend/src/module/downloader/client/qb_downloader.py
@@ -233,21 +233,26 @@ class QbDownloader:
                 delay = 0.1 * (2**attempt)
                 await asyncio.sleep(delay)
                 files = await self.torrents_files(torrent_hash)
+                if files is None:
+                    logger.warning(
+                        "[Downloader] Failed to verify rename: could not fetch file list"
+                    )
+                    continue  # Retry on next attempt
+                found_old = False
                 for f in files:
                     if f.get("name") == new_path:
                         return True
                     if f.get("name") == old_path:
-                        # File still has old name - break inner loop and retry
-                        if attempt < 2:
-                            break
-                        # Final attempt failed
-                        logger.debug(
-                            "[Downloader] Rename API returned 200 but file unchanged: %s", old_path
-                        )
-                        return False
-                # new_path found or old_path not found
-                return True
-            return True
+                        found_old = True
+                if not found_old:
+                    # Neither old nor new path found - rename likely succeeded
+                    return True
+                # File still has old name - will retry outer loop
+            # All retries exhausted, file still has old name
+            logger.debug(
+                "[Downloader] Rename API returned 200 but file unchanged: %s", old_path
+            )
+            return False
         except (httpx.ConnectError, httpx.RequestError, httpx.TimeoutException) as e:
             logger.warning(f"[Downloader] Failed to rename file {old_path}: {e}")
             return False

--- a/backend/src/test/test_qb_rename.py
+++ b/backend/src/test/test_qb_rename.py
@@ -1,0 +1,428 @@
+"""Unit tests for QbDownloader torrents_rename_file method.
+
+Covers the low-level qBittorrent rename-file API call including:
+- Success path with and without verification
+- Verification polling with exponential backoff
+- HTTP 409 conflict
+- HTTP non-200/non-409 responses
+- Network errors (ConnectError, RequestError, TimeoutException)
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from module.downloader.client.qb_downloader import QbDownloader
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_resp(status_code, text=""):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    return resp
+
+
+def _build_authenticated_qb(host="localhost:8080"):
+    """Create an authenticated QbDownloader with a mock AsyncClient."""
+    qb = QbDownloader(host=host, username="admin", password="pass", ssl=False)
+    qb._client = AsyncMock()
+    return qb
+
+
+# ---------------------------------------------------------------------------
+# Success: no verify
+# ---------------------------------------------------------------------------
+
+
+class TestRenameFileSuccessWithoutVerify:
+    """torrents_rename_file with verify=False returns True on HTTP 200."""
+
+    @pytest.mark.parametrize("status_text", ["", "Ok.", "Renamed."])
+    async def test_returns_true_on_200_without_verify(self, status_text):
+        """Any HTTP 200 response returns True when verify=False."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200, status_text)
+
+        result = await qb.torrents_rename_file(
+            torrent_hash="abc123",
+            old_path="old/name.mkv",
+            new_path="new/name.mkv",
+            verify=False,
+        )
+
+        assert result is True
+        qb._client.post.assert_called_once_with(
+            qb._url("torrents/renameFile"),
+            data={"hash": "abc123", "oldPath": "old/name.mkv", "newPath": "new/name.mkv"},
+        )
+
+    async def test_torrents_files_not_called_when_verify_false(self):
+        """When verify=False, the file-list check is skipped entirely."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200)
+
+        await qb.torrents_rename_file(
+            torrent_hash="abc", old_path="a.mkv", new_path="b.mkv", verify=False
+        )
+
+        # torrents_files should not be called (it would fail on our mock anyway)
+        qb._client.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Success: with verify
+# ---------------------------------------------------------------------------
+
+
+class TestRenameFileSuccessWithVerify:
+    """torrents_rename_file with verify=True polls file list after rename."""
+
+    async def test_returns_true_when_new_path_found_on_first_poll(self):
+        """File appears in list on first poll (0.1s delay)."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200)
+
+        # File list shows new path on first GET
+        qb._client.get.return_value = _make_fake_resp(200)
+        qb._client.get.return_value.json.return_value = [
+            {"name": "new/S01E01.mkv"},
+            {"name": "new/S01E01.ass"},
+        ]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await qb.torrents_rename_file(
+                torrent_hash="abc", old_path="old.mkv", new_path="new/S01E01.mkv"
+            )
+
+        assert result is True
+        mock_sleep.assert_called_once_with(0.1)
+        assert qb._client.get.call_count == 1
+
+    async def test_returns_true_after_exponential_backoff_retry(self):
+        """New path eventually appears after a few polls (0.1s, 0.2s, 0.4s delays).
+
+        NOTE: Because the verify loop has a known bug (break exits inner for loop
+        then hits return True), the first poll returns True even when old_path
+        is found. We test the happy path here: new path appears on first poll.
+        """
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200)
+
+        qb._client.get.return_value = _make_fake_resp(200)
+        qb._client.get.return_value.json.return_value = [
+            {"name": "new/S01E01.mkv"},
+        ]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await qb.torrents_rename_file(
+                torrent_hash="abc", old_path="old.mkv", new_path="new/S01E01.mkv"
+            )
+
+        assert result is True
+        # 0.1s delay for the first (and only) poll
+        mock_sleep.assert_called_once_with(0.1)
+
+    async def test_returns_false_when_file_unchanged_after_all_retries(self):
+        """Returns False when file still has old name after 3 verify polls."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200)
+
+        # All polls show old path (file unchanged by qBittorrent)
+        qb._client.get.return_value = _make_fake_resp(200)
+        qb._client.get.return_value.json.return_value = [
+            {"name": "old.mkv"}
+        ]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await qb.torrents_rename_file(
+                torrent_hash="abc", old_path="old.mkv", new_path="new.mkv"
+            )
+
+        assert result is False
+        assert qb._client.get.call_count == 3
+
+    async def test_new_path_eventually_appears(self):
+        """Returns True when new path appears on the 2nd poll (retry works)."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200)
+
+        call_count = [0]
+
+        def file_list_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            resp = MagicMock()
+            resp.status_code = 200
+            if call_count[0] == 1:
+                resp.json.return_value = [{"name": "old.mkv"}]
+            else:
+                resp.json.return_value = [{"name": "new/S02E05.mkv"}]
+            return resp
+
+        qb._client.get.side_effect = file_list_side_effect
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await qb.torrents_rename_file(
+                torrent_hash="abc", old_path="old.mkv", new_path="new/S02E05.mkv"
+            )
+
+        assert result is True
+        assert mock_sleep.call_count == 2  # 0.1s + 0.2s
+        assert mock_sleep.call_args_list[0][0] == (0.1,)
+        assert mock_sleep.call_args_list[1][0] == (0.2,)
+
+    async def test_returns_true_when_neither_path_found(self):
+        """Returns True when neither old nor new path is in the file list
+        (both disappeared = rename likely happened and file was moved further)."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200)
+
+        qb._client.get.return_value = _make_fake_resp(200)
+        qb._client.get.return_value.json.return_value = [{"name": "unrelated.mkv"}]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await qb.torrents_rename_file(
+                torrent_hash="abc", old_path="old.mkv", new_path="new.mkv"
+            )
+
+        assert result is True
+        assert qb._client.get.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# HTTP error responses
+# ---------------------------------------------------------------------------
+
+
+class TestRenameFileHttpErrors:
+    """torrents_rename_file handles HTTP error codes correctly."""
+
+    async def test_409_conflict_returns_false(self):
+        """HTTP 409 (path conflict) returns False immediately."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(409, "Conflict")
+
+        result = await qb.torrents_rename_file(
+            torrent_hash="abc", old_path="a.mkv", new_path="b.mkv"
+        )
+
+        assert result is False
+        qb._client.get.assert_not_called()
+
+    async def test_500_server_error_returns_false(self):
+        """HTTP 500 returns False immediately."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(500)
+
+        result = await qb.torrents_rename_file(
+            torrent_hash="abc", old_path="a.mkv", new_path="b.mkv"
+        )
+
+        assert result is False
+
+    async def test_404_not_found_returns_false(self):
+        """HTTP 404 returns False immediately."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(404)
+
+        result = await qb.torrents_rename_file(
+            torrent_hash="abc", old_path="a.mkv", new_path="b.mkv"
+        )
+
+        assert result is False
+
+    @pytest.mark.parametrize("code", [400, 401, 403, 405, 502, 503])
+    async def test_various_error_codes_return_false(self, code):
+        """Arbitrary non-200 non-409 HTTP codes uniformly return False."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(code)
+
+        result = await qb.torrents_rename_file(
+            torrent_hash="abc", old_path="a.mkv", new_path="b.mkv"
+        )
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Network errors
+# ---------------------------------------------------------------------------
+
+
+class TestRenameFileNetworkErrors:
+    """torrents_rename_file handles network-level errors gracefully."""
+
+    async def test_connect_error_returns_false(self):
+        """httpx.ConnectError → False (not raised)."""
+        qb = _build_authenticated_qb()
+        qb._client.post.side_effect = httpx.ConnectError("Connection refused")
+
+        result = await qb.torrents_rename_file(
+            torrent_hash="abc", old_path="a.mkv", new_path="b.mkv"
+        )
+
+        assert result is False
+
+    async def test_request_error_returns_false(self):
+        """httpx.RequestError → False."""
+        qb = _build_authenticated_qb()
+        qb._client.post.side_effect = httpx.RequestError("Bad request")
+
+        result = await qb.torrents_rename_file(
+            torrent_hash="abc", old_path="a.mkv", new_path="b.mkv"
+        )
+
+        assert result is False
+
+    async def test_timeout_returns_false(self):
+        """httpx.TimeoutException → False."""
+        qb = _build_authenticated_qb()
+        qb._client.post.side_effect = httpx.TimeoutException("Timed out")
+
+        result = await qb.torrents_rename_file(
+            torrent_hash="abc", old_path="a.mkv", new_path="b.mkv"
+        )
+
+        assert result is False
+
+    async def test_connect_error_during_verify_poll_returns_false(self):
+        """Network error during verify polls → retries, then returns False.
+
+        torrents_files() has the @qb_connect_failed_wait decorator which catches
+        ConnectError and retries internally. After all retries fail, it returns
+        None. The fixed code now handles None gracefully with `continue`, and
+        returns False after all 3 verify attempts are exhausted.
+        """
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200)
+        qb._client.get.side_effect = httpx.ConnectError("Lost connection during poll")
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await qb.torrents_rename_file(
+                torrent_hash="abc", old_path="a.mkv", new_path="b.mkv"
+            )
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# API parameters
+# ---------------------------------------------------------------------------
+
+
+class TestRenameFileApiParameters:
+    """torrents_rename_file calls qBittorrent with correct parameters."""
+
+    async def test_correct_url_endpoint(self):
+        """Calls POST /api/v2/torrents/renameFile."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200)
+
+        await qb.torrents_rename_file(
+            torrent_hash="deadbeef", old_path="S1/EP01.mkv", new_path="S1/E01.mkv",
+            verify=False,
+        )
+
+        qb._client.post.assert_called_once()
+        url = qb._client.post.call_args[0][0]
+        assert url == f"http://localhost:8080/api/v2/torrents/renameFile"
+
+    async def test_hash_old_path_new_path_in_post_data(self):
+        """The POST body contains hash, oldPath, and newPath."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200)
+
+        await qb.torrents_rename_file(
+            torrent_hash="aaaa1111",
+            old_path="Season 1/Episode 01.mkv",
+            new_path="Season 1/S01E01.mkv",
+            verify=False,
+        )
+
+        data = qb._client.post.call_args.kwargs["data"]
+        assert data["hash"] == "aaaa1111"
+        assert data["oldPath"] == "Season 1/Episode 01.mkv"
+        assert data["newPath"] == "Season 1/S01E01.mkv"
+
+    async def test_filter_verification_files_by_name(self):
+        """Verification polls torrents/files?hash=... and inspects 'name' field."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200)
+
+        qb._client.get.return_value = _make_fake_resp(200)
+        qb._client.get.return_value.json.return_value = [
+            {"name": "target/S01E05.mkv"},
+        ]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await qb.torrents_rename_file(
+                torrent_hash="hash999",
+                old_path="old/path.mkv",
+                new_path="target/S01E05.mkv",
+            )
+
+        assert result is True
+        qb._client.get.assert_called_once()
+        url = qb._client.get.call_args[0][0]
+        assert "torrents/files" in url
+        assert qb._client.get.call_args.kwargs["params"] == {"hash": "hash999"}
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestRenameFileEdgeCases:
+    """Edge-case handling in torrents_rename_file."""
+
+    async def test_empty_old_path_sent_as_is(self):
+        """Empty oldPath is passed through (qBittorrent returns error)."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(400)
+
+        result = await qb.torrents_rename_file(
+            torrent_hash="abc", old_path="", new_path="new.mkv", verify=False
+        )
+
+        assert result is False
+        assert qb._client.post.call_args.kwargs["data"]["oldPath"] == ""
+
+    async def test_special_characters_in_paths(self):
+        """Paths with CJK and special chars are sent verbatim."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200)
+
+        await qb.torrents_rename_file(
+            torrent_hash="abc",
+            old_path="[ANi] 關於我轉生變成史萊姆這檔事 - 48.5 [1080P].mp4",
+            new_path="关于我转生变成史莱姆这档事 S03E01.mkv",
+            verify=False,
+        )
+
+        data = qb._client.post.call_args.kwargs["data"]
+        assert "48.5" in data["oldPath"]
+        assert "S03E01" in data["newPath"]
+
+    async def test_verify_true_is_the_default(self):
+        """Default verify parameter is True."""
+        qb = _build_authenticated_qb()
+        qb._client.post.return_value = _make_fake_resp(200)
+        qb._client.get.return_value = _make_fake_resp(200)
+        qb._client.get.return_value.json.return_value = [
+            {"name": "new.mkv"}
+        ]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await qb.torrents_rename_file(
+                torrent_hash="abc", old_path="old.mkv", new_path="new.mkv"
+            )
+
+        assert result is True
+        assert qb._client.get.call_count >= 1  # Verify was executed


### PR DESCRIPTION
## 修复的 Bug

### Bug 1: 验证重试循环从未执行（break 作用域错误）

torrents_rename_file() 的验证轮询逻辑中，第 242 行的 break 只跳出了内层 for 循环，随后执行流落到第 249 行的 return True。

效果: 当 qBittorrent 因 seeding 延迟实际重命名时，即使文件列表仍显示旧路径，函数也在第一次轮询就返回 True。后续两次重试永远不会执行。

修复: 用 found_old 布尔标志位替代 break，使外层 for attempt in range(3) 循环能正确重试。全部3次轮询后文件仍为旧名时返回 False。

### Bug 2: 网络错误导致 TypeError 崩溃

torrents_files() 带有 @qb_connect_failed_wait 装饰器。所有重试失败后装饰器隐式返回 None。调用代码直接迭代 None 导致 TypeError。

修复: 添加显式的 if files is None 守卫，若为 None 则 continue 进入下一次验证重试。

## 新增单元测试

新增 test_qb_rename.py (28 个测试)，覆盖成功/验证/HTTP错误/网络错误/API参数/边界。

所有 115 个测试通过（含原有 test_qb_downloader.py 31 个 + test_renamer.py 56 个），零回归。