### PR TITLE
3.2.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,16 +192,16 @@ jobs:
           echo "VERSION='${{ needs.version-info.outputs.version }}'" >> module/__version__.py
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker metadata main
         if: ${{ needs.version-info.outputs.release == 1 && needs.version-info.outputs.dev != 1 }}
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             estrellaxd/auto_bangumi
@@ -213,7 +213,7 @@ jobs:
       - name: Docker metadata dev
         if: ${{ needs.version-info.outputs.dev == 1 }}
         id: meta-dev
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             estrellaxd/auto_bangumi
@@ -224,14 +224,14 @@ jobs:
 
       - name: Login to DockerHub
         if: ${{ needs.version-info.outputs.release == 1 }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to ghcr.io
         if: ${{ needs.version-info.outputs.release == 1 }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -245,7 +245,7 @@ jobs:
 
       - name: Build and push
         if: ${{ needs.version-info.outputs.release == 1 && needs.version-info.outputs.dev != 1 }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           builder: ${{ steps.buildx.output.name }}
@@ -253,12 +253,12 @@ jobs:
           push: True
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha, scope=${{ github.workflow }}
-          cache-to: type=gha, scope=${{ github.workflow }}
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,scope=${{ github.workflow }},ignore-error=true
 
       - name: Build and push dev
         if: ${{ needs.version-info.outputs.dev == 1 }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           builder: ${{ steps.buildx.output.name }}
@@ -266,20 +266,20 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta-dev.outputs.tags }}
           labels: ${{ steps.meta-dev.outputs.labels }}
-          cache-from: type=gha, scope=${{ github.workflow }}
-          cache-to: type=gha, scope=${{ github.workflow }}
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,scope=${{ github.workflow }},ignore-error=true
 
       - name: Build test
         if: ${{ needs.version-info.outputs.release == 0 }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           builder: ${{ steps.buildx.output.name }}
           platforms: linux/amd64,linux/arm64
           push: false
           tags: estrellaxd/auto_bangumi:test
-          cache-from: type=gha, scope=${{ github.workflow }}
-          cache-to: type=gha, scope=${{ github.workflow }}
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,scope=${{ github.workflow }},ignore-error=true
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Re-run of the 3.2.8 release: PR #1047 merged but the docker release build failed three times with `error writing layer blob: failed to reserve cache` (GHA cache write aborting the buildx multi-arch build in docker/build-push-action@v4).

This PR carries the CI fix — docker actions bumped to current majors (`build-push-action@v6`, `setup-buildx@v3`, `metadata@v5`, `login@v3`, `qemu@v3`) and `ignore-error=true` on `cache-to` so a cache write failure can never fail a release again.

Merging this publishes the 3.2.8 images and GitHub release (version from PR title). Release content is unchanged from #1047.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014w1Z6Nxy6XTRgkFXqPr9Zh