### PR TITLE
fix: 为 TMDB 搜索端点添加 language 参数

### DIFF
--- a/backend/src/module/parser/analyser/tmdb_parser.py
+++ b/backend/src/module/parser/analyser/tmdb_parser.py
@@ -63,12 +63,20 @@ class TMDBInfo:
 LANGUAGE = {"zh": "zh-CN", "jp": "ja-JP", "en": "en-US"}
 
 
-def search_url(e):
-    return f"{_tmdb_url()}/3/search/tv?api_key={_api_key()}&page=1&query={e}&include_adult=false"
+def search_url(e, lang="zh-CN"):
+    return (
+        f"{_tmdb_url()}/3/search/tv?api_key={_api_key()}"
+        f"&page=1&query={e}&include_adult=false"
+        f"&language={lang}"
+    )
 
 
-def search_movie_url(e):
-    return f"{_tmdb_url()}/3/search/movie?api_key={_api_key()}&page=1&query={e}&include_adult=false"
+def search_movie_url(e, lang="zh-CN"):
+    return (
+        f"{_tmdb_url()}/3/search/movie?api_key={_api_key()}"
+        f"&page=1&query={e}&include_adult=false"
+        f"&language={lang}"
+    )
 
 
 def info_url(e, key):
@@ -218,16 +226,16 @@ def get_season(seasons: list) -> tuple[int, str | None]:
     return len(ss), ss[-1].get("poster_path")
 
 
-async def _search_movie(title: str, req: RequestContent) -> TMDBInfo | None:
+async def _search_movie(title: str, language: str, req: RequestContent) -> TMDBInfo | None:
     """在 search/movie 端点查询电影/剧场版。
 
     电影没有季度概念，因此不复用剧集的季度/集数聚合逻辑，仅返回标题、原名、
     年份与海报等基本信息。"""
-    url = search_movie_url(title)
+    url = search_movie_url(title, LANGUAGE.get(language, "zh-CN"))
     contents = await req.get_json(url)
     results = (contents or {}).get("results") or []
     if not results:
-        url = search_movie_url(title.replace(" ", ""))
+        url = search_movie_url(title.replace(" ", ""), LANGUAGE.get(language, "zh-CN"))
         contents = await req.get_json(url)
         results = (contents or {}).get("results") or []
     if not results:
@@ -264,23 +272,23 @@ async def tmdb_parser(
     async with RequestContent() as req:
         if is_movie:
             # 已知是电影/剧场版，直接查询 search/movie，跳过剧集搜索
-            result = await _search_movie(title, req)
+            result = await _search_movie(title, language, req)
             _tmdb_cache[cache_key] = result
             return result
-        url = search_url(title)
+        url = search_url(title, LANGUAGE.get(language, "zh-CN"))
         contents = await req.get_json(url)
         if not contents:
-            return await _search_movie(title, req)
+            return await _search_movie(title, language, req)
         contents = (contents or {}).get("results") or []
         if not contents:
-            url = search_url(title.replace(" ", ""))
+            url = search_url(title.replace(" ", ""), LANGUAGE.get(language, "zh-CN"))
             contents_resp = await req.get_json(url)
             if not contents_resp:
-                return await _search_movie(title, req)
+                return await _search_movie(title, language, req)
             contents = (contents_resp or {}).get("results") or []
             if not contents:
                 # search/tv 无结果：回退到 search/movie (剧场版等)
-                return await _search_movie(title, req)
+                return await _search_movie(title, language, req)
         # 判断动画
         if contents:
             matched_id = None
@@ -293,7 +301,7 @@ async def tmdb_parser(
                 # search/tv 有结果但都不是动画：回退到 search/movie (剧场版等)。
                 # Don't cache the negative result permanently — a temporary
                 # TMDB hiccup shouldn't poison this title for the process lifetime.
-                return await _search_movie(title, req)
+                return await _search_movie(title, language, req)
             url_info = info_url(matched_id, language)
             info_content = await req.get_json(url_info)
             season = [


### PR DESCRIPTION
Fixes #1075

`search/tv` 和 `search/movie` 端点调用 TMDB API 时未传递 `language` 参数，
TMDB 默认回退到 `en-US`，影响中文/日文番名的搜索匹配精度。

而 `info_url` 和 `season_url` 已正确传递语言参数，仅搜索端点遗漏。