### PR TITLE
feat(rss): prioritize custom name for TMDB lookup

### DIFF
--- a/backend/src/module/rss/analyser.py
+++ b/backend/src/module/rss/analyser.py
@@ -38,8 +38,14 @@ class RSSAnalyser:
                     if official_title:
                         bangumi.official_title = official_title
         elif rss.parser == "tmdb":
+            rss_name = (rss.name or "").strip()
+            query_title = (
+                rss_name
+                if rss_name and not rss.aggregate
+                else bangumi.official_title
+            )
             tmdb_title, season, year, poster_link = await TitleParser.tmdb_parser(
-                bangumi.official_title,
+                query_title,
                 bangumi.season,
                 settings.rss_parser.language,
                 episode_type=bangumi.episode_type,

--- a/backend/src/test/test_rss_analyser.py
+++ b/backend/src/test/test_rss_analyser.py
@@ -1,0 +1,38 @@
+import pytest
+
+from module.parser import TitleParser
+from module.rss.analyser import RSSAnalyser
+from test.factories import make_bangumi, make_rss_item, make_torrent
+
+
+@pytest.mark.parametrize(
+    ("rss_name", "aggregate", "expected_query"),
+    [
+        ("TMDB Lookup Title", False, "TMDB Lookup Title"),
+        ("   ", False, "Parsed Torrent Title"),
+        ("Aggregate Feed Name", True, "Parsed Torrent Title"),
+    ],
+)
+async def test_tmdb_query_prefers_non_aggregate_rss_name(
+    mocker, rss_name, aggregate, expected_query
+):
+    tmdb_parser = mocker.patch.object(
+        TitleParser,
+        "tmdb_parser",
+        return_value=("Resolved TMDB Title", 2, "2025", "/poster.jpg"),
+    )
+    bangumi = make_bangumi(
+        official_title="Parsed Torrent Title",
+        title_raw="Original Torrent Title",
+        season=1,
+    )
+    rss = make_rss_item(name=rss_name, aggregate=aggregate, parser="tmdb")
+
+    await RSSAnalyser().official_title_parser(bangumi, rss, make_torrent())
+
+    assert tmdb_parser.await_args.args[0] == expected_query
+    assert bangumi.official_title == "Resolved TMDB Title"
+    assert bangumi.title_raw == "Original Torrent Title"
+    assert bangumi.season == 2
+    assert bangumi.year == "2025"
+    assert bangumi.poster_link == "/poster.jpg"


### PR DESCRIPTION
## Summary
- use a non-empty custom RSS name as the TMDB lookup title for non-aggregate subscriptions
- preserve the parsed torrent title fallback for blank names and aggregate feeds
- keep `title_raw` unchanged and add focused analyser coverage

Closes #1061

## Test plan
- [x] `pytest src/test/test_rss_analyser.py src/test/test_api_rss.py src/test/test_rss_engine_new.py -q`
- [x] `ruff check src/module/rss/analyser.py src/test/test_rss_analyser.py`