### PR TITLE
test(e2e): align standalone movie contract

### DIFF
--- a/webui/e2e/specs/tmdb-language.spec.ts
+++ b/webui/e2e/specs/tmdb-language.spec.ts
@@ -69,8 +69,10 @@ test('changing parser language re-queries the same TMDB title in that locale', a
   );
   expect(movie).toMatchObject({
     official_title: 'ローカライズ映画',
-    episode_type: 'movie',
-  });
+    title_raw: 'Localized Movie',
+    year: 2026,
+    group_name: 'E2E',
+  } satisfies Partial<typeof movie>);
 
   await activateTmdbScenario(environment, 'localized-retry-jp');
   const retried = await analyseTmdbFixture(

--- a/webui/e2e/support/issue-data.ts
+++ b/webui/e2e/support/issue-data.ts
@@ -22,6 +22,13 @@ export interface BangumiRecord {
   [key: string]: unknown;
 }
 
+export interface MovieRecord {
+  official_title: string;
+  title_raw: string | null;
+  year: number | null;
+  group_name: string | null;
+}
+
 interface SeedRuleOptions {
   title: string;
   uniqueName: string;
@@ -99,11 +106,21 @@ export async function mockRequests(
   return payload.requests;
 }
 
+export function analyseTmdbFixture(
+  request: APIRequestContext,
+  environment: E2EEnvironment,
+  fixture: 'tmdb-movie.xml'
+): Promise<MovieRecord>;
+export function analyseTmdbFixture(
+  request: APIRequestContext,
+  environment: E2EEnvironment,
+  fixture?: 'tmdb-tv.xml' | 'tmdb-retry.xml'
+): Promise<BangumiRecord>;
 export async function analyseTmdbFixture(
   request: APIRequestContext,
   environment: E2EEnvironment,
   fixture = 'tmdb-tv.xml'
-): Promise<BangumiRecord> {
+): Promise<BangumiRecord | MovieRecord> {
   const response = await requireStatus(
     await request.post('/api/v1/rss/analysis', {
       data: {
@@ -116,7 +133,7 @@ export async function analyseTmdbFixture(
     }),
     200
   );
-  return response.json();
+  return (await response.json()) as BangumiRecord | MovieRecord;
 }
 
 async function analyseParserFixture(


### PR DESCRIPTION
## Summary

- model TMDB analysis fixtures as either BangumiRecord or the standalone MovieRecord
- align the browser movie assertion with the beta.2 response contract
- constrain fixture overloads so unsupported fields are rejected during E2E type checking

## Root cause

Beta.2 moved movie analysis to the standalone Movie model, but the Chromium/WebKit scenario still expected the former Bangumi episode_type field. The runtime E2E had already migrated to the new contract, leaving the browser test and its helper type stale.

## Impact

This restores the required Chromium and WebKit E2E lanes without changing production behavior. Compatible additive response fields remain allowed.

## Validation

- E2E matrix: 54/54 passed
- backend pytest: 2027 passed, 30 skipped
- frontend Vitest: 256 passed
- E2E TypeScript check: passed
- ESLint: 0 errors (10 pre-existing warnings)
- Prettier and git diff --check: passed
- independent subagent review: PASS