### PR TITLE
Send completion notifications when renaming is disabled

### DIFF
--- a/backend/src/module/manager/renamer.py
+++ b/backend/src/module/manager/renamer.py
@@ -247,11 +247,22 @@ class Renamer:
         bangumi_name: str,
         _hash: str,
         episode_offset: int,
+        notify_if_unchanged: bool = False,
     ) -> MediaRenameReport:
         if prepared.source_path == prepared.target_path:
+            notification = None
+            if notify_if_unchanged:
+                notification = Notification(
+                    official_title=bangumi_name,
+                    season=prepared.episode.season,
+                    episode=self._adjust_episode(
+                        prepared.episode.episode, episode_offset
+                    ),
+                )
             return MediaRenameReport(
                 result=RenameResult(RenameOutcome.ALREADY_APPLIED),
                 prepared=prepared,
+                notification=notification,
             )
         result = await self.client.rename_torrent_file(
             _hash=_hash,
@@ -309,6 +320,7 @@ class Renamer:
             bangumi_name=bangumi_name,
             _hash=_hash,
             episode_offset=episode_offset,
+            notify_if_unchanged=method == "none",
         )
 
     @staticmethod
@@ -1168,6 +1180,7 @@ class Renamer:
         identity: RevisionIdentity | None,
         bangumi_name: str,
         episode_offset: int,
+        notify_if_unchanged: bool = False,
     ) -> MediaRenameReport:
         """Claim and execute one non-replacement rename exactly once at a time."""
 
@@ -1299,6 +1312,7 @@ class Renamer:
                 bangumi_name=bangumi_name,
                 _hash=info["hash"],
                 episode_offset=episode_offset,
+                notify_if_unchanged=notify_if_unchanged,
             )
             if report.result.succeeded:
                 await self._set_operation_state(claimed, "done")
@@ -1519,6 +1533,7 @@ class Renamer:
             identity=identity,
             bangumi_name=bangumi_name,
             episode_offset=episode_offset,
+            notify_if_unchanged=method == "none",
         )
 
     @staticmethod

--- a/backend/src/test/test_renamer.py
+++ b/backend/src/test/test_renamer.py
@@ -495,13 +495,13 @@ class TestRenameFile:
 
         renamer.client.client.add_tag.assert_not_awaited()
 
-    async def test_none_method_does_not_tag(self, renamer):
-        """none 方法不做重命名，也不应打处理完成标签。"""
+    async def test_none_method_notifies_without_rename_or_tag(self, renamer):
+        """none 方法不改名、不打标签，但仍返回下载完成通知（#1082）。"""
         ep = EpisodeFile(
             media_path="old.mkv", title="My Anime", season=1, episode=5, suffix=".mkv"
         )
         with patch.object(renamer._parser, "torrent_parser", return_value=ep):
-            await renamer.rename_file(
+            result = await renamer.rename_file(
                 torrent_name="[Sub] My Anime - 05.mkv",
                 media_path="old.mkv",
                 bangumi_name="My Anime",
@@ -510,6 +510,8 @@ class TestRenameFile:
                 _hash="hash123",
             )
 
+        assert result == Notification(official_title="My Anime", season=1, episode=5)
+        renamer.client.client.torrents_rename_file.assert_not_awaited()
         renamer.client.client.add_tag.assert_not_awaited()
 
     async def test_parse_fails_no_remove(self, renamer):


### PR DESCRIPTION
## Summary
- return a download-completion notification when `rename_method` is `none` and the generated path is unchanged
- keep the existing behavior of skipping the rename operation and not adding the `ab:renamed` tag
- preserve unchanged-path behavior for normal rename methods

Fixes #1082

## Tests
- `uv run pytest src/test/test_renamer.py::TestRenameFile::test_none_method_notifies_without_rename_or_tag src/test/test_renamer.py::TestRenameFile::test_same_path_skipped -q` (2 passed)
- `uv run pytest src/test/test_renamer.py -q` (96 passed)
- `uv run pytest src/test -q -m 'not e2e' --basetemp <isolated-temp-dir>` (2027 passed, 3 skipped, 27 deselected)
- `uv run ruff check src`
- `uv run mypy src`
- `uv run black --check src/module/manager/renamer.py src/test/test_renamer.py`