### PR TITLE
修复在HTTP/非安全上下文环境下，复制rss link失效的问题

### DIFF
--- a/webui/src/hooks/useBangumiRuleForm.ts
+++ b/webui/src/hooks/useBangumiRuleForm.ts
@@ -85,26 +85,30 @@ export function useBangumiRuleForm(rule: Ref<BangumiRule>) {
         return true;
       }
     } catch {
+      // 忽略报错，使用 fallback 复制方案
     }
 
     // fallback 方案：创建一个不可见的 textarea 元素，选中内容并执行复制命令
-    const textarea = document.createElement("textarea");
-    textarea.value = text;
-    textarea.style.position = "fixed";
-    textarea.style.left = "-9999px";
-    textarea.style.top = "-9999px";
-    textarea.setAttribute("readonly", "");
+    const textarea = document.createElement('textarea');
+    try {
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.left = '-9999px';
+      textarea.style.top = '-9999px';
+      textarea.setAttribute('readonly', '');
 
-    document.body.appendChild(textarea);
+      document.body.appendChild(textarea);
 
-    textarea.select();
-    textarea.setSelectionRange(0, textarea.value.length);
+      textarea.select();
+      textarea.setSelectionRange(0, textarea.value.length);
 
-    const success = document.execCommand("copy");
+      return document.execCommand('copy');
+    } catch (err) {
+      return false;
+    } finally {
+      document.body.removeChild(textarea);
+    }
 
-    document.body.removeChild(textarea);
-
-    return success;
   }
 
   return {

--- a/webui/src/hooks/useBangumiRuleForm.ts
+++ b/webui/src/hooks/useBangumiRuleForm.ts
@@ -56,7 +56,7 @@ export function useBangumiRuleForm(rule: Ref<BangumiRule>) {
 
   async function copyRssLink(link: string) {
     if (!link) return;
-    await navigator.clipboard.writeText(link);
+    await copyTextWithFallback(link);
     copied.value = true;
     clearTimeout(copyTimer);
     copyTimer = setTimeout(() => {
@@ -67,6 +67,45 @@ export function useBangumiRuleForm(rule: Ref<BangumiRule>) {
   onBeforeUnmount(() => {
     clearTimeout(copyTimer);
   });
+
+  /**
+   * 复制内容到剪切板
+   * 当环境为http 或者非安全上下文时，使用回退方案
+   * 注：回退方案已被标记为 deprecated，未来可能会被移除，所以并不能保证永远生效
+   * @param text
+   */
+  async function copyTextWithFallback(text: string): Promise<boolean> {
+    try {
+      if (
+        // 确认剪切板对象存在且当前为安全上下文
+        navigator.clipboard &&
+        window.isSecureContext
+      ) {
+        await navigator.clipboard.writeText(text);
+        return true;
+      }
+    } catch {
+    }
+
+    // fallback 方案：创建一个不可见的 textarea 元素，选中内容并执行复制命令
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    textarea.style.top = "-9999px";
+    textarea.setAttribute("readonly", "");
+
+    document.body.appendChild(textarea);
+
+    textarea.select();
+    textarea.setSelectionRange(0, textarea.value.length);
+
+    const success = document.execCommand("copy");
+
+    document.body.removeChild(textarea);
+
+    return success;
+  }
 
   return {
     posterSrc,


### PR DESCRIPTION
非 HTTPS / 安全上下文 环境下，chrome等浏览器会禁用 `navigator.clipboard.writeText` 且无法在网站设置中更改此设置，导致在家庭局域网的无https的环境下无法使用复制功能

[[错误报告]非HTTPS下无法使用rss链接复制功能 #1090](https://github.com/EstrellaXD/Auto_Bangumi/issues/1090)