### PR TITLE
fix(parser): accept bilingual releases without episode markers

### DIFF
--- a/backend/src/module/parser/title_parser.py
+++ b/backend/src/module/parser/title_parser.py
@@ -25,6 +25,7 @@ from module.parser.analyser.tokenizer.compat import to_legacy_episode
 from module.parser.release_policy import (
     PersistenceTarget,
     bangumi_episode_type,
+    has_release_evidence,
     is_weak_title_only,
     normalized_season,
     persistence_target,
@@ -235,6 +236,18 @@ def _project_classic_release(
         return None
     episode = to_legacy_episode(release)
     if episode is None:
+        title_count = sum(
+            bool(title)
+            for title in (release.title_en, release.title_zh, release.title_jp)
+        )
+        if (
+            title_count > 1
+            and release.episode is None
+            and release.media_type is MediaType.UNKNOWN
+            and release.release_kind is ReleaseKind.SINGLE
+            and has_release_evidence(release)
+        ):
+            return release
         return None
     return ParsedRelease(
         raw=raw,

--- a/backend/src/test/test_title_parser.py
+++ b/backend/src/test/test_title_parser.py
@@ -212,6 +212,24 @@ class TestRawParserLLMPrimaryMode:
 
 
 class TestConfiguredParserEngine:
+    async def test_classic_admits_bilingual_release_without_episode_marker(self):
+        raw = (
+            "[LoliHouse] 海贼王：女英雄们的故事 / ONE PIECE HEROINES "
+            "[WebRip 1080p HEVC-10bit AAC][简繁内封字幕]"
+        )
+
+        with (
+            patch.object(settings, "llm", LLM(enable=False)),
+            patch.object(settings.rss_parser, "engine", "classic"),
+        ):
+            result = await TitleParser.raw_parser(raw)
+
+        assert isinstance(result, Bangumi)
+        assert result.title_raw == "ONE PIECE HEROINES"
+        assert result.group_name == "LoliHouse"
+        assert result.dpi == "1080p"
+        assert result.eps_collect is True
+
     async def test_classic_keeps_pre_refactor_range_behavior(self):
         raw = "Anime Title - EP01 ~ EP02 [1080p]"
         with (


### PR DESCRIPTION
## New

- Regression coverage for the reported bilingual LoliHouse release title.

## Change

- N/A

## Fix

Closes #1092

The default Classic parser now keeps bilingual releases with concrete release metadata even when the subtitle group omits an episode or special marker. Weak single-title inputs remain rejected.
