### PR TITLE
fix(rss): re-enable disabled RSS on re-subscribe (#1095)

### DIFF
--- a/backend/src/module/database/rss.py
+++ b/backend/src/module/database/rss.py
@@ -17,6 +17,14 @@ class RSSDatabase:
         result = await self.session.execute(statement)
         db_data = result.scalar_one_or_none()
         if db_data:
+            if not db_data.enabled:
+                # 删除番剧时孤儿 RSS 会被停用（#1053）；重新订阅同一 URL 表达了
+                # 恢复更新的意图，必须重新启用，否则番剧会静默断更（#1095）。
+                db_data.enabled = True
+                self.session.add(db_data)
+                await self.session.commit()
+                logger.info("Re-enabled disabled RSS Item %s.", data.url)
+                return True
             logger.debug("RSS Item %s already exists.", data.url)
             return False
         else:

--- a/backend/src/test/test_database.py
+++ b/backend/src/test/test_database.py
@@ -112,6 +112,20 @@ async def test_rss_database(db_session):
     assert result.url == rss_url
 
 
+async def test_rss_add_reenables_disabled_duplicate(db_session):
+    """重新订阅已存在但被停用的 RSS（删除番剧后孤儿停用，#1095）应重新启用。"""
+    rss_url = "https://mikanani.me/RSS/Bangumi?bangumiId=4020&subgroupid=583"
+    db = RSSDatabase(db_session)
+
+    await db.add(RSSItem(url=rss_url, name="Test RSS"))
+    item = await db.search_url(rss_url)
+    await db.disable(item.id)
+
+    assert await db.add(RSSItem(url=rss_url, name="Test RSS")) is True
+    item = await db.search_url(rss_url)
+    assert item.enabled is True
+
+
 # ---------------------------------------------------------------------------
 # TorrentDatabase qb_hash methods
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1095.

删除番剧时孤儿 RSS 会被停用（#1053 的设计），但重新订阅同一 URL 时 `RSSDatabase.add()` 走重复分支直接返回 `False`，从不把 `enabled` 重置回来——重建的番剧静默断更。

## 修复

`add()` 发现 URL 已存在且 `enabled=False` 时重新启用该行并按新增成功返回。聚合订阅不受影响（它们从不被孤儿停用逻辑触碰）。

## 测试

- 新增回归测试 `test_rss_add_reenables_disabled_duplicate`（add → disable → 再 add → enabled 恢复为 True）
- `uv run pytest`：2034 passed, 30 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WTfJZ3EzCpY8SLhzXT6Sf