### PR TITLE
fix(notification): send Telegram posters by source URL with text fallback (#1094)

### DIFF
--- a/backend/src/module/network/request_url.py
+++ b/backend/src/module/network/request_url.py
@@ -181,6 +181,16 @@ class RequestURL:
                 req = await self._client.post(url=url, headers=self.header, data=data)
                 req.raise_for_status()
                 return req
+            except httpx.HTTPStatusError as e:
+                # 服务端拒绝不是连接失败，重试无意义；把状态码和响应体
+                # （如 Telegram 的 JSON description）记下来便于排查（#1094）。
+                logger.warning(
+                    "HTTP %s from %s: %s",
+                    e.response.status_code,
+                    url,
+                    e.response.text[:200],
+                )
+                break
             except httpx.RequestError:
                 logger.warning(f"Cannot connect to {url}. Wait for 5 seconds.")
                 try_time += 1
@@ -219,7 +229,17 @@ class RequestURL:
             )
             req.raise_for_status()
             return req
-        except (httpx.RequestError, httpx.HTTPStatusError):
+        except httpx.HTTPStatusError as e:
+            # 别把服务端拒绝（4xx/5xx）误报成连接失败：响应体里通常带有明确的
+            # 拒绝原因（如 Telegram 的 JSON description），排查 #1094 全靠它。
+            logger.warning(
+                "HTTP %s from %s: %s",
+                e.response.status_code,
+                url,
+                e.response.text[:200],
+            )
+            return None
+        except httpx.RequestError:
             logger.warning(f"Cannot connect to {url}.")
             return None
 

--- a/backend/src/module/notification/providers/telegram.py
+++ b/backend/src/module/notification/providers/telegram.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from module.models.bangumi import Notification
 from module.notification.base import NotificationProvider
-from module.utils import load_image
+from module.utils import load_image, load_poster_url
 
 if TYPE_CHECKING:
     from module.models.config import NotificationProvider as ProviderConfig
@@ -33,12 +33,28 @@ class TelegramProvider(NotificationProvider):
             "disable_notification": True,
         }
 
-        photo = await load_image(notification.poster_path)
-        if photo:
-            resp = await self.post_files(self.photo_url, data, files={"photo": photo})
-        else:
+        # 发图优先级：源 URL（Telegram 服务端拉图）→ 本地缓存 multipart 上传。
+        # 任一失败都降级发纯文本，通知内容不能因海报问题丢失（#1094）。
+        resp = None
+        photo_url = await load_poster_url(notification.poster_path)
+        if photo_url:
+            resp = await self.post_data(self.photo_url, {**data, "photo": photo_url})
+        if resp is None or resp.status_code != 200:
+            photo = await load_image(notification.poster_path)
+            if photo:
+                resp = await self.post_files(
+                    self.photo_url, data, files={"photo": photo}
+                )
+        if resp is None or resp.status_code != 200:
+            if resp is not None:
+                logger.warning(
+                    "Telegram sendPhoto failed (status %s), falling back to text.",
+                    resp.status_code,
+                )
             resp = await self.post_data(self.message_url, data)
 
+        if resp is None:
+            return False
         logger.debug("Telegram notification: %s", resp.status_code)
         return resp.status_code == 200
 

--- a/backend/src/module/parser/analyser/mikan_parser.py
+++ b/backend/src/module/parser/analyser/mikan_parser.py
@@ -54,10 +54,15 @@ async def mikan_parser(homepage: str):
             # (AttributeValueList); "style" is never multi-valued in practice.
             poster_path = poster_div.split("url('")[1].split("')")[0]  # type: ignore[union-attr]
             poster_path = poster_path.split("?")[0]
-            img = await req.get_content(f"https://{root_path}{poster_path}")
+            poster_url = f"https://{root_path}{poster_path}"
+            img = await req.get_content(poster_url)
             suffix = poster_path.split(".")[-1]
             # img can be None if the poster download failed; don't crash on it.
-            poster_link = (await save_image(img, suffix) or "") if img else ""
+            poster_link = (
+                (await save_image(img, suffix, source_url=poster_url) or "")
+                if img
+                else ""
+            )
             return _cache_result(homepage, (poster_link, official_title))
         return _cache_result(homepage, ("", official_title))
 

--- a/backend/src/module/parser/analyser/tmdb_parser.py
+++ b/backend/src/module/parser/analyser/tmdb_parser.py
@@ -374,11 +374,14 @@ async def tmdb_parser(
             year_number = (info_content.get("first_air_date") or "").split("-")[0]
             if poster_path:
                 if not test:
-                    img = await req.get_content(
-                        f"https://image.tmdb.org/t/p/w780{poster_path}"
-                    )
+                    poster_url = f"https://image.tmdb.org/t/p/w780{poster_path}"
+                    img = await req.get_content(poster_url)
                     # img is None if the poster download failed; don't crash on it.
-                    poster_link = await save_image(img, "jpg") if img else None
+                    poster_link = (
+                        await save_image(img, "jpg", source_url=poster_url)
+                        if img
+                        else None
+                    )
                 else:
                     poster_link = "https://image.tmdb.org/t/p/w780" + poster_path
             else:

--- a/backend/src/module/update/cross_version.py
+++ b/backend/src/module/update/cross_version.py
@@ -63,7 +63,9 @@ async def cache_image():
                         # Hash local path
                         img = await req.get_content(bangumi.poster_link)
                         suffix = bangumi.poster_link.split(".")[-1]
-                        img_path = await save_image(img, suffix)
+                        img_path = await save_image(
+                            img, suffix, source_url=bangumi.poster_link
+                        )
                         if img_path:
                             bangumi.poster_link = img_path
                     except Exception as e:

--- a/backend/src/module/utils/__init__.py
+++ b/backend/src/module/utils/__init__.py
@@ -1,1 +1,1 @@
-from .cache_image import load_image, save_image
+from .cache_image import load_image, load_poster_url, save_image

--- a/backend/src/module/utils/cache_image.py
+++ b/backend/src/module/utils/cache_image.py
@@ -1,10 +1,20 @@
 import asyncio
 import hashlib
+import logging
+
+logger = logging.getLogger(__name__)
 
 
-async def save_image(img: bytes | None, suffix: str) -> str | None:
+async def save_image(
+    img: bytes | None, suffix: str, source_url: str | None = None
+) -> str | None:
     """保存图片到本地缓存。文件写入是同步阻塞的，放到线程池中执行，避免
-    在 RSS/通知等异步热路径上阻塞事件循环。"""
+    在 RSS/通知等异步热路径上阻塞事件循环。
+
+    传入 source_url 时在图片旁写一个 ``<name>.url`` sidecar 记录源地址：
+    通知端（Telegram sendPhoto 等）可以直接发 URL 让服务端拉图，绕开本地
+    multipart 上传（#1094）。
+    """
     if img is None:
         # Fetching the poster failed upstream; skip caching instead of
         # crashing on hashlib.md5(None).
@@ -15,18 +25,41 @@ async def save_image(img: bytes | None, suffix: str) -> str | None:
     def _write() -> None:
         with open(image_path, "wb") as f:
             f.write(img)
+        if source_url:
+            with open(f"{image_path}.url", "w", encoding="utf-8") as f:
+                f.write(source_url)
 
     await asyncio.to_thread(_write)
     return f"posters/{img_hash}.{suffix}"
 
 
 async def load_image(img_path: str | None) -> bytes | None:
-    """读取缓存图片。文件读取是同步阻塞的，放到线程池中执行。"""
+    """读取缓存图片。文件读取是同步阻塞的，放到线程池中执行。
+    缓存文件丢失（手动清理、迁移不完整）返回 None，不炸穿通知发送。"""
     if not img_path:
         return None
 
-    def _read() -> bytes:
-        with open(f"data/{img_path}", "rb") as f:
-            return f.read()
+    def _read() -> bytes | None:
+        try:
+            with open(f"data/{img_path}", "rb") as f:
+                return f.read()
+        except OSError:
+            logger.warning("Cached poster %s is missing or unreadable.", img_path)
+            return None
+
+    return await asyncio.to_thread(_read)
+
+
+async def load_poster_url(img_path: str | None) -> str | None:
+    """读取缓存图片对应的源 URL sidecar；旧缓存没有 sidecar 时返回 None。"""
+    if not img_path:
+        return None
+
+    def _read() -> str | None:
+        try:
+            with open(f"data/{img_path}.url", encoding="utf-8") as f:
+                return f.read().strip() or None
+        except OSError:
+            return None
 
     return await asyncio.to_thread(_read)

--- a/backend/src/test/test_cache_image.py
+++ b/backend/src/test/test_cache_image.py
@@ -7,7 +7,7 @@ tmp_path so they never touch the real backend/data/ directory.
 
 import asyncio
 
-from module.utils.cache_image import load_image, save_image
+from module.utils.cache_image import load_image, load_poster_url, save_image
 
 
 class TestSaveImage:
@@ -66,6 +66,14 @@ class TestLoadImage:
 
         assert result == b"cached-poster-bytes"
 
+    async def test_load_image_returns_none_when_file_missing(
+        self, tmp_path, monkeypatch
+    ):
+        """海报缓存文件丢失（手动清理、迁移不完整）不应异常炸穿通知发送。"""
+        monkeypatch.chdir(tmp_path)
+
+        assert await load_image("posters/missing.jpg") is None
+
     async def test_load_image_offloads_read_to_a_thread(self, tmp_path, monkeypatch):
         """The read must go through asyncio.to_thread, not run inline on the
         event loop (regression test for the blocking-I/O fix)."""
@@ -86,3 +94,47 @@ class TestLoadImage:
         await load_image("posters/abc123.jpg")
 
         assert len(calls) == 1
+
+
+class TestPosterUrlSidecar:
+    """保存海报时同时记录源 URL（#1094）：Telegram 等通知可以直接发 URL，
+    让服务端自行拉图，绕开本地 multipart 上传的失败路径。"""
+
+    async def test_save_image_writes_url_sidecar_when_source_url_given(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "data" / "posters").mkdir(parents=True)
+
+        result = await save_image(
+            b"fake-image-bytes", "jpg", source_url="https://mikanani.me/img/a.jpg"
+        )
+
+        assert result is not None
+        sidecar = tmp_path / "data" / f"{result}.url"
+        assert sidecar.read_text() == "https://mikanani.me/img/a.jpg"
+
+    async def test_load_poster_url_returns_stored_source_url(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "data" / "posters").mkdir(parents=True)
+        path = await save_image(
+            b"fake-image-bytes", "jpg", source_url="https://mikanani.me/img/a.jpg"
+        )
+
+        assert await load_poster_url(path) == "https://mikanani.me/img/a.jpg"
+
+    async def test_load_poster_url_returns_none_without_sidecar(
+        self, tmp_path, monkeypatch
+    ):
+        """升级前缓存的旧海报没有 .url sidecar：降级为本地上传，不报错。"""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "data" / "posters").mkdir(parents=True)
+        path = await save_image(b"fake-image-bytes", "jpg")
+
+        assert await load_poster_url(path) is None
+
+    async def test_load_poster_url_returns_none_for_falsy_path(self):
+        assert await load_poster_url(None) is None
+        assert await load_poster_url("") is None

--- a/backend/src/test/test_notification.py
+++ b/backend/src/test/test_notification.py
@@ -241,6 +241,62 @@ class TestTelegramProvider:
         assert result is True
         mock_post.assert_called_once()
 
+    async def test_send_prefers_poster_source_url(self, provider):
+        """有源 URL 时默认让 Telegram 服务端按 URL 拉图，不做本地上传（#1094）。"""
+        notify = Notification(
+            official_title="Test Anime",
+            season=1,
+            episode=5,
+            poster_path="posters/abc123.jpg",
+        )
+
+        with patch.object(provider, "post_data", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = MagicMock(status_code=200)
+            with patch(
+                "module.notification.providers.telegram.load_poster_url",
+                new_callable=AsyncMock,
+            ) as mock_url:
+                mock_url.return_value = "https://mikanani.me/img/a.jpg"
+                with patch(
+                    "module.notification.providers.telegram.load_image",
+                    new_callable=AsyncMock,
+                ) as mock_load:
+                    result = await provider.send(notify)
+
+        assert result is True
+        mock_post.assert_called_once()
+        assert mock_post.call_args[0][0] == provider.photo_url
+        assert mock_post.call_args[0][1]["photo"] == "https://mikanani.me/img/a.jpg"
+        mock_load.assert_not_called()
+
+    async def test_send_falls_back_to_text_when_photo_send_fails(self, provider):
+        """sendPhoto 失败（返回 None）不再崩溃，降级发纯文本消息（#1094）。"""
+        notify = Notification(
+            official_title="Test Anime",
+            season=1,
+            episode=5,
+            poster_path="posters/abc123.jpg",
+        )
+
+        with patch.object(provider, "post_data", new_callable=AsyncMock) as mock_post:
+            mock_post.side_effect = [None, MagicMock(status_code=200)]
+            with patch(
+                "module.notification.providers.telegram.load_poster_url",
+                new_callable=AsyncMock,
+            ) as mock_url:
+                mock_url.return_value = "https://mikanani.me/img/a.jpg"
+                with patch(
+                    "module.notification.providers.telegram.load_image",
+                    new_callable=AsyncMock,
+                ) as mock_load:
+                    mock_load.return_value = None
+                    result = await provider.send(notify)
+
+        assert result is True
+        assert mock_post.call_count == 2
+        assert mock_post.call_args_list[0][0][0] == provider.photo_url
+        assert mock_post.call_args_list[1][0][0] == provider.message_url
+
     async def test_test_success(self, provider):
         """Test method sends test message."""
         with patch.object(provider, "post_data", new_callable=AsyncMock) as mock_post:


### PR DESCRIPTION
Fixes #1094.

下载完成通知在 `sendPhoto` 失败时被整条丢弃：`post_form` 任何错误都返回 `None`，provider 随后在 `resp.status_code` 上抛 `AttributeError`，且没有纯文本兜底。HTTP 4xx/5xx 还被统一打成 "Cannot connect"，掩盖了真实原因（用户日志里 `sendMessage` 可通、`sendPhoto` 必挂，指向的正是被误报的服务端拒绝）。

## 修复

- `save_image` 保存海报时把源 URL 写入同名 `.url` sidecar（Mikan/TMDB/跨版本迁移三处调用点都已传入）；不动数据库 schema，旧缓存无 sidecar 自然降级。
- Telegram 发图链路改为三级：**源 URL（Telegram 服务端自行拉图）→ 本地缓存 multipart 上传 → 纯文本消息**。任何一级失败都不再丢通知、不再崩溃。
- `load_image` 在缓存文件缺失时返回 `None` 而非抛 `FileNotFoundError`。
- `post_url` / `post_form` 把服务端拒绝（记录状态码 + 响应体，Telegram 的 JSON description 会直接出现在日志里）与连接失败分开记录。

## 测试

- `test_send_prefers_poster_source_url`：有 sidecar 时走 URL 发图，不读本地文件
- `test_send_falls_back_to_text_when_photo_send_fails`：sendPhoto 失败降级纯文本，无 `NoneType` 崩溃
- cache_image sidecar 读写 + 旧缓存降级 + 缺文件容错共 5 个新测试
- `uv run pytest`：2034 passed, 30 skipped；ruff/black 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WTfJZ3EzCpY8SLhzXT6Sf