### PR TITLE
fix(config): stop masking empty secrets and scrub corrupted mask sentinels

### DIFF
--- a/backend/src/module/api/config.py
+++ b/backend/src/module/api/config.py
@@ -34,7 +34,9 @@ def _sanitize_dict(d: dict) -> dict:
             result[k] = [
                 _sanitize_dict(item) if isinstance(item, dict) else item for item in v
             ]
-        elif isinstance(v, str) and _is_sensitive(k):
+        elif isinstance(v, str) and v and _is_sensitive(k):
+            # 空值不打掩码：否则未设置密码的字段在前端永远显示一串幻影
+            # 掩码，用户误以为存了密码（并可能因此反复"删除保存"）。
             result[k] = _MASK
         else:
             result[k] = v

--- a/backend/src/module/conf/config.py
+++ b/backend/src/module/conf/config.py
@@ -12,6 +12,35 @@ from .const import DEFAULT_SETTINGS, ENV_TO_ATTR
 logger = logging.getLogger(__name__)
 CONFIG_ROOT = Path("config")
 
+# 与 api/config.py 的掩码约定保持一致（此处不 import，避免 conf ← api 循环）
+_MASK_SENTINEL = "********"
+_SENSITIVE_KEYS = ("password", "api_key", "token", "secret")
+
+
+def _scrub_corrupted_masks(config: dict, path: str = "") -> None:
+    """把字面写入配置的掩码哨兵按空值清洗。
+
+    3.2.3/3.2.4 的配置接口只掩码不恢复，期间保存过配置的用户把 ``********``
+    字面写进了密码/密钥字段（代理/下载器认证因此失败）。原值已不可恢复，
+    置空并告警，提示用户重新输入。
+    """
+    for k, v in config.items():
+        key_path = f"{path}.{k}" if path else k
+        if isinstance(v, dict):
+            _scrub_corrupted_masks(v, key_path)
+        elif isinstance(v, list):
+            for i, item in enumerate(v):
+                if isinstance(item, dict):
+                    _scrub_corrupted_masks(item, f"{key_path}[{i}]")
+        elif v == _MASK_SENTINEL and any(s in k.lower() for s in _SENSITIVE_KEYS):
+            config[k] = ""
+            logger.warning(
+                "Config field '%s' contained a literal mask sentinel "
+                "(corrupted by a 3.2.3/3.2.4 save); cleared it — re-enter "
+                "the secret if one is required.",
+                key_path,
+            )
+
 
 try:
     from module.__version__ import VERSION
@@ -110,6 +139,8 @@ class Settings(Config):
                 # 旧版语义是 LLM 优先解析，迁移用户保持原有行为
                 "mode": "primary",
             }
+
+        _scrub_corrupted_masks(config)
 
         return config
 

--- a/backend/src/test/test_api_config.py
+++ b/backend/src/test/test_api_config.py
@@ -339,6 +339,13 @@ class TestSanitizeDict:
         result = _sanitize_dict({"API_KEY": "abc"})
         assert result["API_KEY"] == "********"
 
+    def test_empty_sensitive_value_is_not_masked(self):
+        """空密码不打掩码：否则前端每次打开都显示一串幻影密码（TG 报告），
+        用户误以为存了密码。"""
+        result = _sanitize_dict({"password": "", "api_key": ""})
+        assert result["password"] == ""
+        assert result["api_key"] == ""
+
     def test_non_sensitive_keys_pass_through(self):
         """Non-sensitive keys are returned unchanged."""
         result = _sanitize_dict({"host": "localhost", "port": 8080, "enable": True})
@@ -412,10 +419,10 @@ class TestSanitizeDict:
         data = response.json()
         # Downloader password should be masked
         assert data["downloader"]["password"] == "********"
-        # LLM api_key should be masked (it's an empty string but still masked)
-        assert data["llm"]["api_key"] == "********"
-        # Legacy OpenAI api_key should be masked too
-        assert data["experimental_openai"]["api_key"] == "********"
+        # Unset (empty) secrets must NOT be masked: a phantom mask makes the
+        # UI show a password where none exists (TG report)
+        assert data["llm"]["api_key"] == ""
+        assert data["experimental_openai"]["api_key"] == ""
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/test/test_config.py
+++ b/backend/src/test/test_config.py
@@ -742,3 +742,34 @@ class TestNetworkBaseUrls:
             await bgm_calendar.fetch_bgm_calendar()
 
         assert captured["url"] == "https://bgm.mirror.test/calendar"
+
+
+# ---------------------------------------------------------------------------
+# Settings._migrate_old_config: 掩码哨兵清洗
+# ---------------------------------------------------------------------------
+
+
+class TestScrubCorruptedMasks:
+    """3.2.3/3.2.4 只掩码不恢复，保存过配置的用户把字面 ******** 写进了
+    密码/密钥字段（代理认证因此失败，TG 报告）。加载时按空值清洗。"""
+
+    def test_literal_mask_in_sensitive_field_is_scrubbed(self):
+        config = {
+            "program": {},
+            "rss_parser": {},
+            "proxy": {"password": "********", "username": "u"},
+            "downloader": {"password": "********"},
+        }
+        result = Settings._migrate_old_config(config)
+        assert result["proxy"]["password"] == ""
+        assert result["downloader"]["password"] == ""
+
+    def test_real_values_and_non_sensitive_keys_are_untouched(self):
+        config = {
+            "program": {},
+            "rss_parser": {},
+            "proxy": {"password": "real-pass", "host": "********"},
+        }
+        result = Settings._migrate_old_config(config)
+        assert result["proxy"]["password"] == "real-pass"
+        assert result["proxy"]["host"] == "********"


### PR DESCRIPTION
TG 用户报告:代理设置每次打开都显示一串不存在的密码,导致代理连不上,只有删除并保存才能临时恢复。

两层根因:

1. `_sanitize_dict` 对**空字符串也打掩码**,GET /config 把未设置的密码返回成 `********`,前端显示幻影密码。修复:只掩码非空值。
2. 3.2.3 引入掩码但 3.2.5 才补上保存时恢复(#995/#1001)——期间保存过配置的用户把字面 `********` 写进了真实的代理/下载器凭据,认证因此失败。修复:配置加载时清洗字面掩码哨兵(原值不可恢复,置空并告警提示重新输入)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WTfJZ3EzCpY8SLhzXT6Sf