### PR TITLE
Release 3.3.5 (mypy fix)

### DIFF
--- a/backend/src/module/database/bangumi.py
+++ b/backend/src/module/database/bangumi.py
@@ -567,11 +567,11 @@ class BangumiDatabase:
         from module.models.torrent import Torrent
 
         await self.session.execute(
-            delete(Torrent).where(Torrent.bangumi_id.is_not(None))  # type: ignore[attr-defined]
+            delete(Torrent).where(Torrent.bangumi_id.is_not(None))  # type: ignore[union-attr]
         )
         await self.session.execute(
             update(Aria2Gid)
-            .where(Aria2Gid.bangumi_id.is_not(None))  # type: ignore[attr-defined]
+            .where(Aria2Gid.bangumi_id.is_not(None))  # type: ignore[union-attr]
             .values(bangumi_id=None)
         )
         await self.session.execute(delete(Bangumi))

--- a/backend/src/test/test_database.py
+++ b/backend/src/test/test_database.py
@@ -119,10 +119,12 @@ async def test_rss_add_reenables_disabled_duplicate(db_session):
 
     await db.add(RSSItem(url=rss_url, name="Test RSS"))
     item = await db.search_url(rss_url)
+    assert item is not None
     await db.disable(item.id)
 
     assert await db.add(RSSItem(url=rss_url, name="Test RSS")) is True
     item = await db.search_url(rss_url)
+    assert item is not None
     assert item.enabled is True
 
 


### PR DESCRIPTION
Type-check fixes for the 3.3.5 release: correct type-ignore codes in BangumiDatabase.delete_all and narrow Optional in the RSS re-enable test. Follow-up to #1101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WTfJZ3EzCpY8SLhzXT6Sf