### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=EstrellaXD/Auto_Bangumi&type=Date)](https://star-history.com/#EstrellaXD/Auto_Bangumi)
+[![Star History Chart](https://star-history.dera.page/svg?repos=EstrellaXD/Auto_Bangumi&type=Date)](https://star-history.dera.page/#EstrellaXD/Auto_Bangumi)
 
 ## 贡献
 


### PR DESCRIPTION
The star history chart in the README no longer renders correctly because the upstream service is broken due to GitHub's stargazer API restrictions. This change points the chart and its link to a working replacement at star-history.dera.page, which requires no API token, so the graph is visible again. The chart was originally introduced in commit e9367e3.