### PR TITLE
feat: add WPUSH notification provider

### DIFF
--- a/backend/src/module/models/config.py
+++ b/backend/src/module/models/config.py
@@ -164,6 +164,16 @@ class NotificationProvider(BaseModel):
     url_: Optional[str] = Field(
         default=None, alias="url", description="URL for generic webhook provider"
     )
+    channel_: Optional[str] = Field(
+        default=None,
+        alias="channel",
+        description="Delivery channel for WPUSH (default wechat)",
+    )
+    topic_code_: Optional[str] = Field(
+        default=None,
+        alias="topic_code",
+        description="Optional WPUSH Topic broadcast code",
+    )
 
     @property
     def token(self) -> str:
@@ -196,6 +206,15 @@ class NotificationProvider(BaseModel):
     @property
     def url(self) -> str:
         return _expand(self.url_)
+
+    @property
+    def channel(self) -> str:
+        return _expand(self.channel_)
+
+    @property
+    def topic_code(self) -> str:
+        return _expand(self.topic_code_)
+
 
 
 class Notification(BaseModel):

--- a/backend/src/module/notification/providers/__init__.py
+++ b/backend/src/module/notification/providers/__init__.py
@@ -10,6 +10,7 @@ from module.notification.providers.server_chan import ServerChanProvider
 from module.notification.providers.telegram import TelegramProvider
 from module.notification.providers.webhook import WebhookProvider
 from module.notification.providers.wecom import WecomProvider
+from module.notification.providers.wpush import WPushProvider
 
 if TYPE_CHECKING:
     from module.notification.base import NotificationProvider
@@ -25,6 +26,8 @@ PROVIDER_REGISTRY: dict[str, type["NotificationProvider"]] = {
     "gotify": GotifyProvider,
     "pushover": PushoverProvider,
     "webhook": WebhookProvider,
+    "wpush": WPushProvider,
+    "w-push": WPushProvider,
 }
 
 __all__ = [
@@ -37,4 +40,5 @@ __all__ = [
     "GotifyProvider",
     "PushoverProvider",
     "WebhookProvider",
+    "WPushProvider",
 ]

--- a/backend/src/module/notification/providers/wpush.py
+++ b/backend/src/module/notification/providers/wpush.py
@@ -1,0 +1,81 @@
+"""WPUSH notification provider."""
+
+import logging
+from typing import TYPE_CHECKING
+
+from module.models.bangumi import Notification
+from module.notification.base import NotificationProvider
+
+if TYPE_CHECKING:
+    from module.models.config import NotificationProvider as ProviderConfig
+
+logger = logging.getLogger(__name__)
+
+API_URL = "https://api.wpush.cn/api/v1/send"
+DEFAULT_CHANNEL = "wechat"
+
+
+class WPushProvider(NotificationProvider):
+    """WPUSH multi-channel notification provider.
+
+    Docs: https://wpush.cn/docs
+    Success when JSON ``code === 0``.
+    """
+
+    def __init__(self, config: "ProviderConfig"):
+        super().__init__(config)
+        self.apikey = config.token
+        self.channel = (config.channel or DEFAULT_CHANNEL).strip() or DEFAULT_CHANNEL
+        self.topic_code = (config.topic_code or "").strip()
+
+    def _payload(self, title: str, content: str) -> dict:
+        data = {
+            "apikey": self.apikey,
+            "title": title,
+            "content": content,
+            "channel": self.channel,
+        }
+        if self.topic_code:
+            data["topic_code"] = self.topic_code
+        return data
+
+    def _ok(self, resp) -> bool:
+        if resp is None or resp.status_code != 200:
+            return False
+        try:
+            body = resp.json()
+        except Exception:
+            return False
+        return body.get("code") == 0
+
+    async def send(self, notification: Notification) -> bool:
+        """Send notification via WPUSH."""
+        text = self._format_message(notification)
+        resp = await self._post_json(
+            API_URL, self._payload(notification.official_title, text)
+        )
+        logger.debug("WPUSH notification: %s", getattr(resp, "status_code", None))
+        return self._ok(resp)
+
+    async def test(self) -> tuple[bool, str]:
+        """Test WPUSH configuration by sending a test message."""
+        data = self._payload(
+            "AutoBangumi 通知测试",
+            "通知测试成功！\nNotification test successful!",
+        )
+        try:
+            resp = await self._post_json(API_URL, data)
+            if self._ok(resp):
+                return True, "WPUSH test message sent successfully"
+            try:
+                body = resp.json() if resp is not None else {}
+            except Exception:
+                body = {}
+            return False, f"WPUSH API error: {body.get('message') or getattr(resp, 'status_code', 'no response')}"
+        except Exception as e:
+            return False, f"WPUSH test failed: {e}"
+
+    async def _deliver_text(self, title: str, body: str) -> bool:
+        """Deliver a system event via WPUSH."""
+        resp = await self._post_json(API_URL, self._payload(title, body))
+        return self._ok(resp)

--- a/backend/src/test/test_notification.py
+++ b/backend/src/test/test_notification.py
@@ -25,6 +25,7 @@ from module.notification.providers import (
     TelegramProvider,
     WebhookProvider,
     WecomProvider,
+    WPushProvider,
 )
 
 # ---------------------------------------------------------------------------
@@ -65,6 +66,11 @@ class TestProviderRegistry:
     def test_webhook(self):
         """Registry contains WebhookProvider for 'webhook' type."""
         assert PROVIDER_REGISTRY["webhook"] is WebhookProvider
+
+    def test_wpush(self):
+        """Registry contains WPushProvider for 'wpush' type."""
+        assert PROVIDER_REGISTRY["wpush"] is WPushProvider
+        assert PROVIDER_REGISTRY["w-push"] is WPushProvider
 
     def test_unknown_type(self):
         """Returns None for unknown notification type."""
@@ -775,3 +781,47 @@ class TestConfigMigration:
 
         assert len(new_config.providers) == 1
         assert new_config.providers[0].type == "discord"
+
+
+class TestWPushProvider:
+    def test_payload_defaults(self):
+        config = ProviderConfig(type="wpush", enabled=True, token="WPUSHkey")
+        provider = WPushProvider(config)
+        data = provider._payload("t", "c")
+        assert data == {
+            "apikey": "WPUSHkey",
+            "title": "t",
+            "content": "c",
+            "channel": "wechat",
+        }
+
+    def test_payload_with_channel_and_topic(self):
+        config = ProviderConfig(
+            type="wpush",
+            enabled=True,
+            token="WPUSHkey",
+            channel="feishu",
+            topic_code="abc",
+        )
+        provider = WPushProvider(config)
+        data = provider._payload("t", "c")
+        assert data["channel"] == "feishu"
+        assert data["topic_code"] == "abc"
+
+    @pytest.mark.asyncio
+    async def test_deliver_text_posts_json(self):
+        config = ProviderConfig(type="wpush", enabled=True, token="WPUSHkey")
+        provider = WPushProvider(config)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"code": 0}
+        with patch.object(provider, "_post_json", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_resp
+            ok = await provider._deliver_text("hello", "world")
+        assert ok is True
+        mock_post.assert_awaited_once()
+        args = mock_post.await_args.args
+        assert args[0] == "https://api.wpush.cn/api/v1/send"
+        assert args[1]["apikey"] == "WPUSHkey"
+        assert args[1]["title"] == "hello"
+        assert args[1]["content"] == "world"

--- a/webui/src/components/setting/config-notification.vue
+++ b/webui/src/components/setting/config-notification.vue
@@ -24,6 +24,7 @@ const providerTypes: {
   { value: 'gotify', label: 'Gotify' },
   { value: 'pushover', label: 'Pushover' },
   { value: 'webhook', label: 'Webhook' },
+  { value: 'wpush', label: 'WPUSH' },
 ];
 
 // Provider field configurations
@@ -70,6 +71,19 @@ const providerFields: Record<
   pushover: [
     { key: 'user_key', label: 'User Key', placeholder: 'user key' },
     { key: 'api_token', label: 'API Token', placeholder: 'api token' },
+  ],
+  wpush: [
+    { key: 'token', label: 'API Key', placeholder: 'WPUSHxxxxxxxx' },
+    {
+      key: 'channel',
+      label: 'Channel (optional)',
+      placeholder: 'wechat / app / feishu / ...',
+    },
+    {
+      key: 'topic_code',
+      label: 'Topic Code (optional)',
+      placeholder: 'topic code',
+    },
   ],
   webhook: [
     {
@@ -132,6 +146,7 @@ function getProviderIcon(type: string): string {
     gotify: 'i-carbon-notification-filled',
     pushover: 'i-carbon-mobile',
     webhook: 'i-carbon-webhook',
+    wpush: 'i-simple-icons-wechat',
   };
   return icons[type] || 'i-carbon-notification';
 }

--- a/webui/src/components/setup/wizard-step-notification.vue
+++ b/webui/src/components/setup/wizard-step-notification.vue
@@ -14,6 +14,7 @@ const notificationTypes = [
   { id: 1, label: 'Server Chan', value: 'server-chan' },
   { id: 2, label: 'Bark', value: 'bark' },
   { id: 3, label: 'WeChat Work', value: 'wecom' },
+  { id: 4, label: 'WPUSH', value: 'wpush' },
 ];
 
 async function testNotification() {

--- a/webui/src/pages/index/config.vue
+++ b/webui/src/pages/index/config.vue
@@ -132,6 +132,7 @@ const sections: ConfigSection[] = [
       'gotify',
       'pushover',
       'webhook',
+      'wpush',
       'token',
     ],
   },

--- a/webui/types/config.ts
+++ b/webui/types/config.ts
@@ -21,7 +21,8 @@ export type NotificationType = [
   'wecom',
   'gotify',
   'pushover',
-  'webhook'
+  'webhook',
+  'wpush'
 ];
 /** LLM 提供商 id（内置三家 + 预设/插件，开放集合） */
 export type LLMProviderId = string;
@@ -98,6 +99,8 @@ export interface NotificationProviderConfig {
   device_key?: string;
   user_key?: string;
   api_token?: string;
+  channel?: string;
+  topic_code?: string;
   template?: string;
   url?: string;
 }


### PR DESCRIPTION
## Summary
- Add **WPUSH** notification provider (`wpush` / `w-push`), parallel to Server Chan / Bark.
- API: `POST https://api.wpush.cn/api/v1/send` with `apikey` / `title` / `content` / `channel` (default `wechat`), optional `topic_code`.
- Success when JSON `code === 0`.

## Changes
- `backend/.../providers/wpush.py` + registry
- Optional `channel` / `topic_code` on notification provider config
- WebUI provider type + setup wizard + unit tests

## Config
| Field | Required | Notes |
|---|---|---|
| `token` | yes | WPUSH API Key from https://wpush.cn/settings |
| `channel` | no | `wechat` / `app` / `sms` / `mail` / `webhook` / `dingtalk` / `feishu` / `wechat_work` / `clawbot` / `qqbot` |
| `topic_code` | no | Topic broadcast code |

Docs: https://wpush.cn/docs

## Test plan
- [ ] `pytest backend/src/test/test_notification.py::TestWPushProvider`
- [ ] WebUI: add WPUSH provider with API Key, click Test
- [ ] Optional: set channel / topic_code
